### PR TITLE
feat: ransackによるテキスト検索機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,4 @@ end
 
 gem "tailwindcss-rails", "~> 4.4"
 gem "kaminari"
+gem "ransack", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
+    ransack (4.4.1)
+      activerecord (>= 7.2)
+      activesupport (>= 7.2)
+      i18n
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -390,6 +394,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3)
+  ransack (~> 4.0)
   rspec-rails
   rubocop-rails-omakase
   selenium-webdriver
@@ -497,6 +502,7 @@ CHECKSUMS
   railties (7.2.3) sha256=6eb010a6bfe6f223e783f739ddfcbdb5b88b1f3a87f7739f0a0685e466250422
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  ransack (4.4.1) sha256=6aeaac36fc19088570e10da1044e6cfd88c740e20f871b84566fd30e32b7a63d
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,8 +1,26 @@
 class ArticlesController < ApplicationController
   def index
-    events = Event.includes(:period, :category).all
-    characters = Character.all
+    @q_event = Event.ransack(event_search_params)
+    @q_character = Character.ransack(character_search_params)
+
+    events = @q_event.result.includes(:period, :category)
+    characters = @q_character.result
+
     all_articles = events + characters
     @articles = Kaminari.paginate_array(all_articles).page(params[:page]).per(6)
+  end
+
+  private
+
+  # Event: title, descriptionで検索
+  def event_search_params
+    return {} unless params[:q].present?
+    { title_or_description_cont: params[:q][:keyword] }
+  end
+
+  # Character: name, description, achievementで検索
+  def character_search_params
+    return {} unless params[:q].present?
+    { name_or_description_or_achievement_cont: params[:q][:keyword] }
   end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -6,4 +6,12 @@ class Character < ApplicationRecord
   validates :name, presence: true
   validates :description, presence: true
   validates :achievement, presence: true
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name description achievement]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,4 +8,12 @@ class Event < ApplicationRecord
   validates :title, presence: true
   validates :year, presence: true
   validates :description, presence: true
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[title description]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/views/articles/_search_bar.html.erb
+++ b/app/views/articles/_search_bar.html.erb
@@ -1,16 +1,18 @@
 <div class="bg-white border-b border-[#e2e8f0] py-10 px-48">
   <div class="max-w-[896px] w-full mx-auto px-4">
-    <div class="relative">
-      <div class="absolute inset-y-0 left-4 flex items-center">
-        <svg class="size-6 text-[#6b7280]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
-        </svg>
+    <%= form_with url: articles_path, method: :get, local: true do |f| %>
+      <div class="relative">
+        <div class="absolute inset-y-0 left-4 flex items-center">
+          <svg class="size-6 text-[#6b7280]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+          </svg>
+        </div>
+        <%= f.text_field :q,
+          value: params.dig(:q, :keyword),
+          name: "q[keyword]",
+          placeholder: "出来事、人物、時代を検索...",
+          class: "w-full bg-white border-2 border-[#f1f5f9] rounded-lg pl-[50px] pr-[18px] py-5 text-lg text-[#6b7280] focus:outline-none focus:border-[#3713ec]" %>
       </div>
-      <input
-        type="text"
-        placeholder="出来事、人物、時代を検索..."
-        class="w-full bg-white border-2 border-[#f1f5f9] rounded-lg pl-[50px] pr-[18px] py-5 text-lg text-[#6b7280] focus:outline-none focus:border-[#3713ec]"
-      />
-    </div>
+    <% end %>
   </div>
 </div>

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -42,5 +42,50 @@ RSpec.describe "Articles", type: :request do
         expect(response.body).not_to include("page=2")
       end
     end
+
+    context "テキスト検索" do
+      let!(:event_renaissance) { create(:event, title: "ルネサンス", description: "文化復興の時代") }
+      let!(:event_baroque) { create(:event, title: "バロック音楽", description: "装飾的な音楽様式") }
+      let!(:char_davinci) { create(:character, name: "ダ・ヴィンチ", description: "万能の天才", achievement: "モナ・リザを制作") }
+      let!(:char_bach) { create(:character, name: "バッハ", description: "音楽の父", achievement: "マタイ受難曲を作曲") }
+
+      it "Eventのtitleで検索できる" do
+        get articles_path, params: { q: { keyword: "ルネサンス" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("ルネサンス")
+        expect(response.body).not_to include("バロック")
+      end
+
+      it "Characterのnameで検索できる" do
+        get articles_path, params: { q: { keyword: "ヴィンチ" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("ダ・ヴィンチ")
+        expect(response.body).not_to include("バッハ")
+      end
+
+      it "Eventのdescriptionで検索できる" do
+        get articles_path, params: { q: { keyword: "装飾的" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("バロック")
+      end
+
+      it "Characterのachievementで検索できる" do
+        get articles_path, params: { q: { keyword: "モナ・リザ" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("ダ・ヴィンチ")
+      end
+
+      it "検索キーワードが空の場合は全件表示される" do
+        get articles_path, params: { q: { keyword: "" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("4件")
+      end
+
+      it "該当なしの場合は0件になる" do
+        get articles_path, params: { q: { keyword: "存在しないキーワード" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("0件")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- ransack 4.xを導入し、記事一覧ページにキーワード検索機能を追加
- Event（title, description）とCharacter（name, description, achievement）を横断検索
- 検索バーのUIモックをform_withで動的フォームに置き換え

## Test plan
- [x] RSpecテスト6ケース追加（全パス）
- [ ] キーワード入力でEvent・Characterが絞り込まれることを確認
- [ ] 空検索で全件表示されることを確認
- [ ] 該当なしの場合に0件と表示されることを確認
- [ ] ページネーションとの併用が正常に動作することを確認
- [ ] RuboCop通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)