### PR TITLE
feat: ドロップダウンによるソート機能の実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -9,7 +9,7 @@ class ArticlesController < ApplicationController
     events = apply_filters(events)
     characters = apply_filters(characters)
 
-    all_articles = events + characters
+    all_articles = sort_articles(events + characters)
     @articles = Kaminari.paginate_array(all_articles).page(params[:page]).per(6)
 
     @periods = Period.all
@@ -18,6 +18,18 @@ class ArticlesController < ApplicationController
   end
 
   private
+
+  def sort_articles(articles)
+    case params[:sort]
+    when "year_desc"
+      articles.sort_by { |a| -(a.year || 0) }
+    when "name_asc"
+      articles.sort_by { |a| a.is_a?(Event) ? a.title.to_s : a.name.to_s }
+    else
+      # デフォルト: 年代（古い順）
+      articles.sort_by { |a| a.year || 0 }
+    end
+  end
 
   def apply_filters(scope)
     scope = scope.where(period_id: params[:period_ids]) if params[:period_ids].present?

--- a/app/views/articles/_filter_sidebar.html.erb
+++ b/app/views/articles/_filter_sidebar.html.erb
@@ -1,7 +1,8 @@
 <aside class="w-64 shrink-0 flex flex-col gap-8">
   <%= form_with url: articles_path, method: :get, local: true, data: { controller: "filter", action: "change->filter#submit" } do |f| %>
-    <%# 検索キーワードを保持 %>
+    <%# 検索キーワードとソートを保持 %>
     <%= hidden_field_tag "q[keyword]", params.dig(:q, :keyword) %>
+    <%= hidden_field_tag :sort, params[:sort] %>
 
     <%# 時代フィルター（チェックボックス） %>
     <div class="flex flex-col gap-4">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -13,13 +13,22 @@
       <p class="text-sm text-[#64748b]">
         検索結果: <span class="font-semibold text-[#0f172a]"><%= @articles.total_count %>件</span>
       </p>
-      <div class="flex items-center gap-2">
+      <%= form_with url: articles_path, method: :get, local: true, class: "flex items-center gap-2", data: { controller: "filter", action: "change->filter#submit" } do %>
         <span class="text-sm text-[#64748b]">並び替え:</span>
-        <select class="text-sm border border-[#e2e8f0] rounded-lg px-3 py-2">
-          <option>年代</option>
-          <option>名前順</option>
-        </select>
-      </div>
+        <%# フィルター・検索パラメータを保持 %>
+        <%= hidden_field_tag "q[keyword]", params.dig(:q, :keyword) %>
+        <% params[:period_ids]&.each do |id| %>
+          <%= hidden_field_tag "period_ids[]", id %>
+        <% end %>
+        <%= hidden_field_tag :study_unit_id, params[:study_unit_id] %>
+        <%= hidden_field_tag :region_id, params[:region_id] %>
+        <%= select_tag :sort,
+          options_for_select(
+            [["年代（古い順）", "year_asc"], ["年代（新しい順）", "year_desc"], ["名前順", "name_asc"]],
+            params[:sort] || "year_asc"
+          ),
+          class: "text-sm border border-[#e2e8f0] rounded-lg px-3 py-2" %>
+      <% end %>
     </div>
 
     <%# カードグリッド %>

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -160,5 +160,40 @@ RSpec.describe "Articles", type: :request do
         expect(response.body).not_to include("水墨画")
       end
     end
+
+    context "ソート" do
+      let!(:event_old) { create(:event, title: "古代イベント", year: -500) }
+      let!(:event_new) { create(:event, title: "近代イベント", year: 1800) }
+      let!(:char_middle) { create(:character, name: "中世キャラ", year: 1200) }
+
+      it "年代（古い順）でソートできる" do
+        get articles_path, params: { sort: "year_asc" }
+        body = response.body
+        expect(body.index("古代イベント")).to be < body.index("中世キャラ")
+        expect(body.index("中世キャラ")).to be < body.index("近代イベント")
+      end
+
+      it "年代（新しい順）でソートできる" do
+        get articles_path, params: { sort: "year_desc" }
+        body = response.body
+        expect(body.index("近代イベント")).to be < body.index("中世キャラ")
+        expect(body.index("中世キャラ")).to be < body.index("古代イベント")
+      end
+
+      it "名前順でソートできる" do
+        get articles_path, params: { sort: "name_asc" }
+        body = response.body
+        # Eventはtitle、Characterはnameで比較（Unicode順: 中 < 古 < 近）
+        expect(body.index("中世キャラ")).to be < body.index("古代イベント")
+        expect(body.index("古代イベント")).to be < body.index("近代イベント")
+      end
+
+      it "デフォルトは年代（古い順）" do
+        get articles_path
+        body = response.body
+        expect(body.index("古代イベント")).to be < body.index("中世キャラ")
+        expect(body.index("中世キャラ")).to be < body.index("近代イベント")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- 年代（古い順）、年代（新しい順）、名前順の3種類でEventsとCharactersを並び替え可能にした
- デフォルトは年代（古い順）
- フィルターとソートの状態を相互にhidden fieldで保持

## Test plan
- [x] 年代（古い順）でソートできること
- [x] 年代（新しい順）でソートできること
- [x] 名前順でソートできること
- [x] デフォルトが年代（古い順）であること
- [x] 既存テスト（ページネーション・検索・フィルター）が通ること
- [x] 全65テスト通過、rubocop違反なし
- [x] 画面上で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)