### PR TITLE
fix: 人物カードの年表示をDBの値に変更

### DIFF
--- a/app/views/articles/_card.html.erb
+++ b/app/views/articles/_card.html.erb
@@ -42,7 +42,7 @@
     <%# コンテンツ %>
     <div class="p-5 flex flex-col gap-2">
       <div class="flex items-center justify-between">
-        <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider">ルネサンス期</span>
+        <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider"><%= article.year %>年</span>
         <div class="flex items-center gap-1">
           <svg class="size-3 text-[#94a3b8]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>


### PR DESCRIPTION
## Summary
- 人物カードに固定表示されていた「ルネサンス���」を `article.year` の動的表示に修正

## Test plan
- [x] 全65テスト通過、rubocop違反なし
- [x] 画面上で年が正しく表示されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)