### PR TITLE
fix: seedファイルを既存データも更新される形式に変更

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,126 +24,139 @@ unit_romanticism = StudyUnit.find_or_create_by!(name: "ロマン主義")
 
 # === 出来事 ===
 
-event1 = Event.find_or_create_by!(title: "イタリア・ルネサンス") do |e|
-  e.year = 1400
-  e.description = "中世から近代への移行期を象徴するヨーロッパの歴史的時代で、15世紀から16世紀にかけて最盛期を迎えました。"
-  e.image_url = "/renaissance.jpg"
-  e.period = period_medieval
-  e.category = category_event
-  e.study_unit = unit_renaissance
-  e.region = region_europe
-end
+event1 = Event.find_or_initialize_by(title: "イタリア・ルネサンス")
+event1.update!(
+  year: 1400,
+  description: "中世から近代への移行期を象徴するヨーロッパの歴史的時代で、15世紀から16世紀にかけて最盛期を迎えました。",
+  image_url: "/renaissance.jpg",
+  period: period_medieval,
+  category: category_event,
+  study_unit: unit_renaissance,
+  region: region_europe
+)
 
-event2 = Event.find_or_create_by!(title: "パルテノン神殿の建設") do |e|
-  e.year = -447
-  e.description = "アテネのアクロポリスに建てられた古代ギリシャの神殿。ドーリア式建築の最高傑作とされる。"
-  e.period = period_ancient
-  e.category = category_art
-  e.study_unit = unit_greek
-  e.region = region_europe
-end
+event2 = Event.find_or_initialize_by(title: "パルテノン神殿の建設")
+event2.update!(
+  year: -447,
+  description: "アテネのアクロポリスに建てられた古代ギリシャの神殿。ドーリア式建築の最高傑作とされる。",
+  period: period_ancient,
+  category: category_art,
+  study_unit: unit_greek,
+  region: region_europe
+)
 
-event3 = Event.find_or_create_by!(title: "システィーナ礼拝堂天井画の完成") do |e|
-  e.year = 1512
-  e.description = "ミケランジェロが約4年をかけて完成させた天井画。『アダムの創造』などの場面が描かれている。"
-  e.period = period_medieval
-  e.category = category_art
-  e.study_unit = unit_renaissance
-  e.region = region_europe
-end
+event3 = Event.find_or_initialize_by(title: "システィーナ礼拝堂天井画の完成")
+event3.update!(
+  year: 1512,
+  description: "ミケランジェロが約4年をかけて完成させた天井画。『アダムの創造』などの場面が描かれている。",
+  period: period_medieval,
+  category: category_art,
+  study_unit: unit_renaissance,
+  region: region_europe
+)
 
-event4 = Event.find_or_create_by!(title: "グーテンベルクの活版印刷") do |e|
-  e.year = 1450
-  e.description = "ヨハネス・グーテンベルクが活版印刷技術を発明。知識の普及と宗教改革に大きな影響を与えた。"
-  e.period = period_medieval
-  e.category = category_event
-  e.study_unit = unit_renaissance
-  e.region = region_europe
-end
+event4 = Event.find_or_initialize_by(title: "グーテンベルクの活版印刷")
+event4.update!(
+  year: 1450,
+  description: "ヨハネス・グーテンベルクが活版印刷技術を発明。知識の普及と宗教改革に大きな影響を与えた。",
+  period: period_medieval,
+  category: category_event,
+  study_unit: unit_renaissance,
+  region: region_europe
+)
 
-event5 = Event.find_or_create_by!(title: "バロック音楽の隆盛") do |e|
-  e.year = 1600
-  e.description = "装飾的で劇的な表現を特徴とする音楽様式が発展。オペラの誕生もこの時代に起こった。"
-  e.period = period_early_modern
-  e.category = category_music
-  e.study_unit = unit_baroque
-  e.region = region_europe
-end
+event5 = Event.find_or_initialize_by(title: "バロック音楽の隆盛")
+event5.update!(
+  year: 1600,
+  description: "装飾的で劇的な表現を特徴とする音楽様式が発展。オペラの誕生もこの時代に起こった。",
+  period: period_early_modern,
+  category: category_music,
+  study_unit: unit_baroque,
+  region: region_europe
+)
 
-event6 = Event.find_or_create_by!(title: "フランス革命と芸術") do |e|
-  e.year = 1789
-  e.description = "フランス革命は芸術にも大きな影響を与え、新古典主義からロマン主義への転換を促した。"
-  e.period = period_modern
-  e.category = category_event
-  e.study_unit = unit_romanticism
-  e.region = region_europe
-end
+event6 = Event.find_or_initialize_by(title: "フランス革命と芸術")
+event6.update!(
+  year: 1789,
+  description: "フランス革命は芸術にも大きな影響を与え、新古典主義からロマン主義への転換を促した。",
+  period: period_modern,
+  category: category_event,
+  study_unit: unit_romanticism,
+  region: region_europe
+)
 
-event7 = Event.find_or_create_by!(title: "『神曲』の執筆") do |e|
-  e.year = 1308
-  e.description = "ダンテ・アリギエーリによる叙事詩。地獄・煉獄・天国の三部構成で、中世文学の最高傑作とされる。"
-  e.period = period_medieval
-  e.category = category_literature
-  e.study_unit = unit_renaissance
-  e.region = region_europe
-end
+event7 = Event.find_or_initialize_by(title: "『神曲』の執筆")
+event7.update!(
+  year: 1308,
+  description: "ダンテ・アリギエーリによる叙事詩。地獄・煉獄・天国の三部構成で、中世文学の最高傑作とされる。",
+  period: period_medieval,
+  category: category_literature,
+  study_unit: unit_renaissance,
+  region: region_europe
+)
 
 # === 人物 ===
 
-char1 = Character.find_or_create_by!(name: "レオナルド・ダ・ヴィンチ") do |c|
-  c.description = "盛期ルネサンスを代表するイタリアの多才な人物で、画家、彫刻家、建築家、技術者、科学者として活躍しました。"
-  c.achievement = "『モナ・リザ』『最後の晩餐』などの傑作を残し、解剖学・工学・天文学など多分野で先駆的な業績を残した。"
-  c.image_url = "/leonardo.jpg"
-  c.study_unit = unit_renaissance
-  c.period = period_medieval
-  c.region = region_europe
-  c.year = 1452
-end
+char1 = Character.find_or_initialize_by(name: "レオナルド・ダ・ヴィンチ")
+char1.update!(
+  description: "盛期ルネサンスを代表するイタリアの多才な人物で、画家、彫刻家、建築家、技術者、科学者として活躍しました。",
+  achievement: "『モナ・リザ』『最後の晩餐』などの傑作を残し、解剖学・工学・天文学など多分野で先駆的な業績を残した。",
+  image_url: "/leonardo.jpg",
+  study_unit: unit_renaissance,
+  period: period_medieval,
+  region: region_europe,
+  year: 1452
+)
 
-char2 = Character.find_or_create_by!(name: "ミケランジェロ") do |c|
-  c.description = "イタリア・ルネサンス期の彫刻家・画家・建築家。"
-  c.achievement = "『ダビデ像』『システィーナ礼拝堂天井画』『ピエタ』などを制作。"
-  c.study_unit = unit_renaissance
-  c.period = period_medieval
-  c.region = region_europe
-  c.year = 1475
-end
+char2 = Character.find_or_initialize_by(name: "ミケランジェロ")
+char2.update!(
+  description: "イタリア・ルネサンス期の彫刻家・画家・建築家。",
+  achievement: "『ダビデ像』『システィーナ礼拝堂天井画』『ピエタ』などを制作。",
+  study_unit: unit_renaissance,
+  period: period_medieval,
+  region: region_europe,
+  year: 1475
+)
 
-char3 = Character.find_or_create_by!(name: "ソクラテス") do |c|
-  c.description = "古代ギリシャの哲学者。西洋哲学の基礎を築いた人物。"
-  c.achievement = "対話法（問答法）を確立し、プラトンやアリストテレスに多大な影響を与えた。"
-  c.study_unit = unit_greek
-  c.period = period_ancient
-  c.region = region_europe
-  c.year = -470
-end
+char3 = Character.find_or_initialize_by(name: "ソクラテス")
+char3.update!(
+  description: "古代ギリシャの哲学者。西洋哲学の基礎を築いた人物。",
+  achievement: "対話法（問答法）を確立し、プラトンやアリストテレスに多大な影響を与えた。",
+  study_unit: unit_greek,
+  period: period_ancient,
+  region: region_europe,
+  year: -470
+)
 
-char4 = Character.find_or_create_by!(name: "ヨハン・セバスティアン・バッハ") do |c|
-  c.description = "ドイツのバロック音楽の作曲家。「音楽の父」と称される。"
-  c.achievement = "『マタイ受難曲』『平均律クラヴィーア曲集』など、バロック音楽の集大成となる作品を残した。"
-  c.study_unit = unit_baroque
-  c.period = period_early_modern
-  c.region = region_europe
-  c.year = 1685
-end
+char4 = Character.find_or_initialize_by(name: "ヨハン・セバスティアン・バッハ")
+char4.update!(
+  description: "ドイツのバロック音楽の作曲家。「音楽の父」と称される。",
+  achievement: "『マタイ受難曲』『平均律クラヴィーア曲集』など、バロック音楽の集大成となる作品を残した。",
+  study_unit: unit_baroque,
+  period: period_early_modern,
+  region: region_europe,
+  year: 1685
+)
 
-char5 = Character.find_or_create_by!(name: "ダンテ・アリギエーリ") do |c|
-  c.description = "中世イタリアの詩人。イタリア文学の父と呼ばれる。"
-  c.achievement = "叙事詩『神曲』を執筆し、イタリア語の文語としての地位を確立した。"
-  c.study_unit = unit_renaissance
-  c.period = period_medieval
-  c.region = region_europe
-  c.year = 1265
-end
+char5 = Character.find_or_initialize_by(name: "ダンテ・アリギエーリ")
+char5.update!(
+  description: "中世イタリアの詩人。イタリア文学の父と呼ばれる。",
+  achievement: "叙事詩『神曲』を執筆し、イタリア語の文語としての地位を確立した。",
+  study_unit: unit_renaissance,
+  period: period_medieval,
+  region: region_europe,
+  year: 1265
+)
 
-char6 = Character.find_or_create_by!(name: "ウジェーヌ・ドラクロワ") do |c|
-  c.description = "フランス・ロマン主義を代表する画家。"
-  c.achievement = "『民衆を導く自由の女神』を制作し、ロマン主義絵画の象徴的存在となった。"
-  c.study_unit = unit_romanticism
-  c.period = period_modern
-  c.region = region_europe
-  c.year = 1798
-end
+char6 = Character.find_or_initialize_by(name: "ウジェーヌ・ドラクロワ")
+char6.update!(
+  description: "フランス・ロマン主義を代表する画家。",
+  achievement: "『民衆を導く自由の女神』を制作し、ロマン主義絵画の象徴的存在となった。",
+  study_unit: unit_romanticism,
+  period: period_modern,
+  region: region_europe,
+  year: 1798
+)
 
 # === 出来事と人物の関連付け ===
 EventCharacter.find_or_create_by!(event: event1, character: char1)


### PR DESCRIPTION
## Summary
- `find_or_create_by!` を `find_or_initialize_by` + `update!` に変更
- デプロイ時の `db:seed` で既存レコードの新カラム（year, period, region）が反映されるようにした
- 本番環境で人物カードの年が表示されない��題を解決

## Test plan
- [x] `db:seed` 実行後、既存Characterのyearが正しく更新されること
- [x] 全65テスト通過、rubocop違反���し

🤖 Generated with [Claude Code](https://claude.com/claude-code)