### PR TITLE
feat: 人物詳細ページ（characters#show）を実装

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -1,0 +1,5 @@
+class CharactersController < ApplicationController
+  def show
+    @character = Character.includes(:period, :region, :study_unit, events: [ :category, :period, :region ]).find(params[:id])
+  end
+end

--- a/app/views/articles/_card.html.erb
+++ b/app/views/articles/_card.html.erb
@@ -28,7 +28,8 @@
   </div>
 
 <% elsif article.is_a?(Character) %>
-  <div class="bg-white border border-[#e2e8f0] rounded-lg overflow-hidden">
+  <%= link_to character_path(article), class: "block" do %>
+  <div class="bg-white border border-[#e2e8f0] rounded-lg overflow-hidden hover:shadow-md transition-shadow">
     <%# サムネイル %>
     <div class="relative h-48 bg-[#f1f5f9]">
       <% if article.image_url.present? %>
@@ -55,4 +56,5 @@
       <p class="text-sm text-[#475569] line-clamp-2"><%= article.description %></p>
     </div>
   </div>
+  <% end %>
 <% end %>

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -1,0 +1,121 @@
+<%# Hero Section %>
+<section class="relative overflow-hidden bg-[#142283]">
+  <% if @character.image_url.present? %>
+    <div class="absolute inset-0">
+      <%= image_tag @character.image_url, class: "w-full h-full object-cover mix-blend-overlay", alt: @character.name %>
+    </div>
+  <% end %>
+  <div class="absolute inset-0 opacity-90" style="background-image: linear-gradient(154deg, rgb(0, 11, 96) 0%, rgb(20, 34, 131) 100%)"></div>
+  <div class="relative max-w-[1280px] mx-auto px-20 py-20 flex flex-col justify-center min-h-[500px]">
+    <%# バッジ %>
+    <div class="pb-6">
+      <span class="inline-flex items-center gap-2 bg-[rgba(236,119,0,0.2)] rounded-full px-4 py-1.5">
+        <svg class="w-3 h-3 text-[#ec7700]" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+        </svg>
+        <span class="text-xs font-semibold tracking-[1.2px] uppercase text-[#ec7700]"><%= @character.period.name %> · <%= @character.region.name %></span>
+      </span>
+    </div>
+    <%# タイトル %>
+    <div class="pb-4">
+      <h1 class="text-[72px] font-extrabold text-white leading-[72px] tracking-[-3.6px]"><%= @character.name %></h1>
+      <p class="text-[48px] font-semibold text-[#dfe0ff] leading-[48px] tracking-[-3.6px] opacity-90"><%= @character.name %></p>
+    </div>
+    <%# 説明文 %>
+    <div class="max-w-[672px]">
+      <p class="text-2xl font-light text-white/80 leading-8 tracking-[0.6px]"><%= @character.description %></p>
+    </div>
+    <%# 年代 %>
+    <p class="text-4xl font-normal text-white leading-[44px]">（<%= @character.year %>年）</p>
+  </div>
+</section>
+
+<%# Main Content %>
+<div class="bg-[#eeeeee]">
+  <div class="max-w-[1280px] mx-auto px-8 py-20">
+    <div class="bg-white flex flex-col gap-20 p-12">
+
+      <%# Overview Section %>
+      <section class="flex flex-col gap-8">
+        <div class="flex items-center gap-4">
+          <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
+          <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">概要 (Overview)</h2>
+        </div>
+        <div class="flex flex-col gap-6">
+          <p class="text-base text-[#454652] leading-[26px]"><%= @character.description %></p>
+        </div>
+      </section>
+
+      <%# Key Works Section %>
+      <% if @character.events.any? %>
+        <section class="flex flex-col gap-8">
+          <div class="flex items-center gap-4">
+            <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
+            <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">代表作 (Key Works)</h2>
+          </div>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <%# 上段カード（白背景） %>
+            <% @character.events.limit(2).each do |event| %>
+              <div class="bg-white rounded-xl p-8 shadow-[0px_24px_40px_-4px_rgba(25,28,29,0.06)] flex flex-col gap-2 overflow-hidden">
+                <p class="text-sm font-semibold tracking-[1.4px] uppercase text-[#ec7700] leading-5"><%= event.year %>年</p>
+                <h3 class="text-2xl font-bold text-[#191c1d] leading-8"><%= event.title %></h3>
+                <div class="pt-2">
+                  <p class="text-base text-[#454652] leading-[26px]"><%= event.description %></p>
+                </div>
+                <% if event.image_url.present? %>
+                  <div class="h-52 rounded-lg overflow-hidden opacity-90 mt-2">
+                    <%= image_tag event.image_url, class: "w-full h-full object-cover", alt: event.title %>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+
+            <%# TODO: 本リリースで特集テーブルを作成し、特集カードのデータを管理する。現状はeventsの3件目以降を表示している。 %>
+            <% @character.events.offset(2).each do |event| %>
+              <div class="md:col-span-2 bg-[#142283] rounded-xl p-8 shadow-[0px_24px_40px_-4px_rgba(25,28,29,0.06)] flex overflow-hidden h-80">
+                <div class="flex-1 flex flex-col gap-2 pr-8">
+                  <p class="text-sm font-semibold tracking-[1.4px] uppercase text-[#dfe0ff] leading-5"><%= event.year %>年</p>
+                  <h3 class="text-[30px] font-bold text-white leading-9"><%= event.title %></h3>
+                  <div class="pt-2">
+                    <p class="text-base text-[rgba(223,224,255,0.8)] leading-[26px]"><%= event.description %></p>
+                  </div>
+                </div>
+                <div class="aspect-square h-full bg-white/10 rounded-lg flex items-center justify-center flex-shrink-0">
+                  <% if event.image_url.present? %>
+                    <%= image_tag event.image_url, class: "w-full h-full object-cover rounded-lg", alt: event.title %>
+                  <% else %>
+                    <svg class="w-7 h-11 text-white/50" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                    </svg>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+
+      <%# Achievements Section %>
+      <section class="flex flex-col gap-8">
+        <div class="flex items-center gap-4">
+          <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
+          <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">業績 (Achievements)</h2>
+        </div>
+        <div class="flex flex-col gap-6">
+          <div class="bg-[#f3f4f5] rounded-xl p-6 flex gap-6 items-start">
+            <div class="flex-shrink-0">
+              <svg class="w-5 h-7 text-[#ec7700]" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
+              </svg>
+            </div>
+            <div class="flex flex-col gap-2">
+              <p class="text-base text-[#454652] leading-[26px]"><%= @character.achievement %></p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
    root "static_pages#top"
 
   resources :articles, only: [ :index ]
+  resources :characters, only: [ :show ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -95,6 +95,36 @@ event7.update!(
   region: region_europe
 )
 
+event8 = Event.find_or_initialize_by(title: "モナ・リザの制作")
+event8.update!(
+  year: 1503,
+  description: "スフマート技法を用い、神秘的な微笑みを浮かべた肖像画の傑作。背景の空気遠近法も特徴的です。",
+  period: period_medieval,
+  category: category_art,
+  study_unit: unit_renaissance,
+  region: region_europe
+)
+
+event9 = Event.find_or_initialize_by(title: "最後の晩餐の制作")
+event9.update!(
+  year: 1495,
+  description: "一点透視図法を完璧に駆使し、イエスが裏切りを告げた瞬間の弟子の動揺を見事に描き出しています。",
+  period: period_medieval,
+  category: category_art,
+  study_unit: unit_renaissance,
+  region: region_europe
+)
+
+event10 = Event.find_or_initialize_by(title: "ウィトルウィウス的人体図")
+event10.update!(
+  year: 1490,
+  description: "黄金比と幾何学を人体に適用。芸術と科学、数学が見事に融合したルネサンス人文主義の象徴です。",
+  period: period_medieval,
+  category: category_art,
+  study_unit: unit_renaissance,
+  region: region_europe
+)
+
 # === 人物 ===
 
 char1 = Character.find_or_initialize_by(name: "レオナルド・ダ・ヴィンチ")
@@ -160,6 +190,9 @@ char6.update!(
 
 # === 出来事と人物の関連付け ===
 EventCharacter.find_or_create_by!(event: event1, character: char1)
+EventCharacter.find_or_create_by!(event: event8, character: char1)
+EventCharacter.find_or_create_by!(event: event9, character: char1)
+EventCharacter.find_or_create_by!(event: event10, character: char1)
 EventCharacter.find_or_create_by!(event: event3, character: char2)
 EventCharacter.find_or_create_by!(event: event5, character: char4)
 EventCharacter.find_or_create_by!(event: event7, character: char5)

--- a/spec/requests/characters_spec.rb
+++ b/spec/requests/characters_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Characters", type: :request do
+  describe "GET /characters/:id" do
+    let!(:character) do
+      create(:character,
+        name: "レオナルド・ダ・ヴィンチ",
+        description: "ルネサンスの万能の天才",
+        achievement: "絵画、科学、工学を融合した知の巨人",
+        year: 1452
+      )
+    end
+
+    context "正常系" do
+      it "詳細ページが表示される" do
+        get character_path(character)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "人物の基本情報が表示される" do
+        get character_path(character)
+        expect(response.body).to include("レオナルド・ダ・ヴィンチ")
+        expect(response.body).to include("ルネサンスの万能の天才")
+        expect(response.body).to include("絵画、科学、工学を融合した知の巨人")
+        expect(response.body).to include("1452")
+      end
+
+      it "時代・地域の情報が表示される" do
+        get character_path(character)
+        expect(response.body).to include(character.period.name)
+        expect(response.body).to include(character.region.name)
+      end
+    end
+
+    context "関連する出来事がある場合" do
+      let!(:event1) { create(:event, title: "モナ・リザの制作", year: 1503) }
+      let!(:event2) { create(:event, title: "最後の晩餐の制作", year: 1495) }
+
+      before do
+        create(:event_character, event: event1, character: character)
+        create(:event_character, event: event2, character: character)
+      end
+
+      it "関連する出来事が表示される" do
+        get character_path(character)
+        expect(response.body).to include("モナ・リザの制作")
+        expect(response.body).to include("最後の晩餐の制作")
+      end
+    end
+
+    context "関連する出来事がない場合" do
+      it "エラーにならず表示される" do
+        get character_path(character)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "存在しないIDの場合" do
+      it "404エラーになる" do
+        get character_path(id: 99999)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- 人物（characters）の詳細ページを新規実装（ルーティング、コントローラー、ビュー）
- Figmaデザインに基づいたUI（Hero、Overview、Key Works、Achievementsセクション）
- 一覧ページの人物カードから詳細ページへの遷移リンクを追加
- ダ・ヴィンチの関連イベント3件をseedデータに追加

## Test plan
- [x] RSpecリクエストスペック6件追加・全71件通過
- [x] RuboCop違反なし
- [x] ブラウザで人物詳細ページの表示確認
- [x] 一覧ページからのリンク遷移確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)