### PR TITLE
feat: タイムラインページ（timelines#show）を実装

### DIFF
--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -1,0 +1,10 @@
+class TimelinesController < ApplicationController
+  def show
+    @study_unit = StudyUnit.find(params[:id])
+    @study_units = StudyUnit.all
+    @events = @study_unit.events
+      .includes(:category, :period, :region, :characters)
+      .order(:year)
+    @categories = @events.map(&:category).uniq
+  end
+end

--- a/app/helpers/timelines_helper.rb
+++ b/app/helpers/timelines_helper.rb
@@ -1,0 +1,24 @@
+module TimelinesHelper
+  CATEGORY_COLORS = {
+    "出来事" => { bg: "#dbeafe", border: "#93c5fd", text: "#2563eb" },
+    "芸術"  => { bg: "#dcfce7", border: "#86efac", text: "#16a34a" },
+    "文学"  => { bg: "#f3e8ff", border: "#d8b4fe", text: "#9333ea" },
+    "音楽"  => { bg: "#fef3c7", border: "#fcd34d", text: "#d97706" }
+  }.freeze
+
+  DEFAULT_COLOR = { bg: "#f3f4f6", border: "#d1d5db", text: "#4b5563" }.freeze
+
+  def category_colors(category)
+    CATEGORY_COLORS[category.name] || DEFAULT_COLOR
+  end
+
+  def category_badge_style(category)
+    colors = category_colors(category)
+    "background-color: #{colors[:bg]}; color: #{colors[:text]};"
+  end
+
+  def category_legend_style(category)
+    colors = category_colors(category)
+    "background-color: #{colors[:bg]}; border-color: #{colors[:border]};"
+  end
+end

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  toggle() {
+    this.menuTarget.classList.toggle("hidden")
+  }
+
+  // メニュー外クリックで閉じる
+  close(event) {
+    if (!this.element.contains(event.target)) {
+      this.menuTarget.classList.add("hidden")
+    }
+  }
+
+  connect() {
+    this.boundClose = this.close.bind(this)
+    document.addEventListener("click", this.boundClose)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.boundClose)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("hello", HelloController)
 
 import FilterController from "./filter_controller"
 application.register("filter", FilterController)
+
+import DropdownController from "./dropdown_controller"
+application.register("dropdown", DropdownController)

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,6 +15,19 @@
     <%# ナビゲーション %>
     <nav class="flex items-center gap-8">
       <%= link_to "記事一覧", articles_path, class: "text-[14px] text-[#475569] font-medium hover:text-[#0f172a]" %>
+      <div class="relative" data-controller="dropdown">
+        <button type="button" data-action="click->dropdown#toggle" class="text-[14px] text-[#475569] font-medium hover:text-[#0f172a] flex items-center gap-1">
+          タイムライン
+          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+          </svg>
+        </button>
+        <div data-dropdown-target="menu" class="hidden absolute top-full right-0 mt-2 w-48 bg-white border border-[#e2e8f0] rounded-lg shadow-lg py-2 z-50">
+          <% StudyUnit.all.each do |unit| %>
+            <%= link_to unit.name, timeline_path(unit), class: "block px-4 py-2 text-sm text-[#475569] hover:bg-[#f8fafc] hover:text-[#0f172a]" %>
+          <% end %>
+        </div>
+      </div>
       <%= link_to "ログイン", "#", class: "text-[14px] text-[#475569] font-medium hover:text-[#0f172a]" %>
       <%= link_to "会員登録", "#", class: "bg-[#3713ec] text-white text-[14px] font-medium px-5 py-2 rounded-lg shadow-[0px_4px_6px_-1px_rgba(55,19,236,0.2),0px_2px_4px_-2px_rgba(55,19,236,0.2)] hover:opacity-90" %>
     </nav>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -1,0 +1,89 @@
+<div class="flex h-[calc(100vh-64px)]">
+  <%# サイドバー %>
+  <aside class="w-64 border-r border-[#e5e7eb] bg-white flex flex-col justify-between px-6 py-6 flex-shrink-0">
+    <div>
+      <p class="text-xs font-medium text-[#9ca3af] tracking-[1.2px] uppercase mb-6">学習単元を選択</p>
+      <nav class="flex flex-col">
+        <% @study_units.each do |unit| %>
+          <%= link_to timeline_path(unit), class: "px-4 py-3 rounded-lg text-xl font-medium #{unit == @study_unit ? 'text-[#3713ec]' : 'text-[#94a3b8] hover:text-[#3713ec]'}" do %>
+            <%= unit.name %>
+          <% end %>
+        <% end %>
+      </nav>
+    </div>
+    <div class="border-t border-[#f3f4f6] pt-6">
+      <p class="text-xs font-medium text-[#9ca3af] tracking-[1.2px] uppercase mb-4">凡例</p>
+      <div class="flex flex-col gap-2">
+        <% @categories.each do |category| %>
+          <div class="flex items-center gap-2">
+            <div class="size-3 rounded-full border" style="<%= category_legend_style(category) %>"></div>
+            <span class="text-xs text-[#111827]"><%= category.name %></span>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </aside>
+
+  <%# メインエリア %>
+  <div class="flex-1 bg-[#fafafa] flex flex-col overflow-hidden">
+    <%# ヘッダー %>
+    <div class="backdrop-blur-sm bg-white/50 border-b border-[#e5e7eb] px-6 py-4 flex-shrink-0">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-xl font-medium text-black tracking-[3.2px]"><%= @study_unit.name %></h1>
+        </div>
+      </div>
+    </div>
+
+    <%# タイムラインエリア %>
+    <div class="flex-1 relative overflow-x-auto" data-controller="timeline">
+      <%# 水平ライン %>
+      <div class="absolute left-0 right-0 top-1/2 h-0.5 bg-[#3713ec] opacity-30 -translate-y-1/2" style="min-width: <%= [@events.count * 352 + 400, 100].max %>px;"></div>
+
+      <%# タイムラインカード %>
+      <div class="flex items-center gap-16 px-12 absolute top-1/2 -translate-y-1/2" style="min-width: <%= [@events.count * 352 + 400, 100].max %>px;">
+        <% @events.each_with_index do |event, index| %>
+          <div class="flex flex-col items-center <%= index.even? ? 'pt-8' : 'pb-8' %>">
+            <% if index.even? %>
+              <%# カード上 + ドット下 %>
+              <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm w-72 p-6 flex flex-col">
+                <div class="mb-2">
+                  <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-[0.25px] uppercase" style="<%= category_badge_style(event.category) %>">
+                    <%= event.category.name %>
+                  </span>
+                </div>
+                <h3 class="text-lg font-medium text-[#111827] mb-1"><%= event.title %></h3>
+                <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
+                <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= event.description %></p>
+                <% if event.characters.any? %>
+                  <p class="text-sm text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
+                <% end %>
+              </div>
+              <div class="flex flex-col items-center py-8 w-4">
+                <div class="size-4 rounded-full bg-[#3713ec] border-4 border-white shadow-md"></div>
+              </div>
+            <% else %>
+              <%# ドット上 + カード下 %>
+              <div class="flex flex-col items-center py-8 w-4">
+                <div class="size-4 rounded-full bg-[#3713ec] border-4 border-white shadow-md"></div>
+              </div>
+              <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm w-72 p-6 flex flex-col">
+                <div class="mb-2">
+                  <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-[0.25px] uppercase" style="<%= category_badge_style(event.category) %>">
+                    <%= event.category.name %>
+                  </span>
+                </div>
+                <h3 class="text-lg font-medium text-[#111827] mb-1"><%= event.title %></h3>
+                <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
+                <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= event.description %></p>
+                <% if event.characters.any? %>
+                  <p class="text-sm text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   resources :articles, only: [ :index ]
   resources :characters, only: [ :show ]
+  resources :timelines, only: [ :show ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/requests/timelines_spec.rb
+++ b/spec/requests/timelines_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "Timelines", type: :request do
+  describe "GET /timelines/:id" do
+    let!(:study_unit) { create(:study_unit, name: "ルネサンス") }
+
+    context "正常系" do
+      it "タイムラインページが表示される" do
+        get timeline_path(study_unit)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "学習単元名が表示される" do
+        get timeline_path(study_unit)
+        expect(response.body).to include("ルネサンス")
+      end
+    end
+
+    context "eventsがある場合" do
+      let!(:category) { create(:category, name: "芸術") }
+      let!(:event1) { create(:event, title: "モナ・リザの制作", year: 1503, study_unit: study_unit, category: category) }
+      let!(:event2) { create(:event, title: "最後の晩餐の制作", year: 1495, study_unit: study_unit, category: category) }
+
+      it "eventsが年代順に表示される" do
+        get timeline_path(study_unit)
+        body = response.body
+        expect(body).to include("モナ・リザの制作")
+        expect(body).to include("最後の晩餐の制作")
+        expect(body.index("最後の晩餐の制作")).to be < body.index("モナ・リザの制作")
+      end
+
+      it "カテゴリ名が表示される" do
+        get timeline_path(study_unit)
+        expect(response.body).to include("芸術")
+      end
+
+      it "年代が表示される" do
+        get timeline_path(study_unit)
+        expect(response.body).to include("1503")
+        expect(response.body).to include("1495")
+      end
+    end
+
+    context "関連する人物がいる場合" do
+      let!(:event) { create(:event, title: "ルネサンスの始まり", study_unit: study_unit) }
+      let!(:character) { create(:character, name: "ダ・ヴィンチ") }
+
+      before do
+        create(:event_character, event: event, character: character)
+      end
+
+      it "代表人物が表示される" do
+        get timeline_path(study_unit)
+        expect(response.body).to include("ダ・ヴィンチ")
+      end
+    end
+
+    context "サイドバー" do
+      let!(:other_unit) { create(:study_unit, name: "バロック") }
+
+      it "全学習単元が表示される" do
+        get timeline_path(study_unit)
+        expect(response.body).to include("ルネサンス")
+        expect(response.body).to include("バロック")
+      end
+    end
+
+    context "存在しないIDの場合" do
+      it "404エラーになる" do
+        get timeline_path(id: 99999)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- 学習単元ごとのeventsを年代順に横スクロールタイムラインで表示するページを新規実装
- ヘッダーにタイムラインへのドロップダウンメニューを追加
- カテゴリごとの色分けバッジ・凡例を表示

## Test plan
- [x] RSpecリクエストスペック8件追加・全79件通過
- [x] RuboCop違反なし
- [x] ブラウザでタイムラインの横スクロール確認
- [x] ヘッダーのドロップダウンから学習単元を選択して遷移確認
- [x] サイドバーで学習単元の切り替え確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)