### PR TITLE
feat: 記事のお気に入り機能を実装

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,25 @@
+class FavoritesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    favorites = current_user.favorites.includes(:favorable)
+    all_articles = favorites.map(&:favorable).compact
+    @articles = Kaminari.paginate_array(all_articles).page(params[:page]).per(6)
+  end
+
+  def create
+    @favorite = current_user.favorites.build(favorable_type: params[:favorable_type], favorable_id: params[:favorable_id])
+
+    if @favorite.save
+      redirect_back fallback_location: articles_path, notice: "お気に入りに追加しました"
+    else
+      redirect_back fallback_location: articles_path, alert: "お気に入りの追加に失敗しました"
+    end
+  end
+
+  def destroy
+    @favorite = current_user.favorites.find(params[:id])
+    @favorite.destroy
+    redirect_back fallback_location: articles_path, notice: "お気に入りを解除しました"
+  end
+end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -4,6 +4,7 @@ class Character < ApplicationRecord
   belongs_to :region
   has_many :event_characters
   has_many :events, through: :event_characters
+  has_many :favorites, as: :favorable, dependent: :destroy
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,6 +5,7 @@ class Event < ApplicationRecord
   belongs_to :region
   has_many :event_characters
   has_many :characters, through: :event_characters
+  has_many :favorites, as: :favorable, dependent: :destroy
 
   validates :title, presence: true
   validates :year, presence: true

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :favorable, polymorphic: true
+
+  validates :user_id, uniqueness: { scope: [ :favorable_type, :favorable_id ] }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :favorites, dependent: :destroy
+
   validates :name, presence: true
 end

--- a/app/views/articles/_card.html.erb
+++ b/app/views/articles/_card.html.erb
@@ -1,62 +1,71 @@
-<% if article.is_a?(Event) %>
-  <%= link_to event_path(article), class: "block" do %>
-  <div class="bg-white border border-[#e2e8f0] rounded-lg overflow-hidden hover:shadow-md transition-shadow">
-    <%# サムネイル %>
-    <div class="relative h-48 bg-[#f1f5f9]">
-      <% if article.image_url.present? %>
-        <%= image_tag article.image_url, class: "w-full h-full object-cover", alt: article.title %>
-      <% end %>
-      <div class="absolute top-3 left-3 bg-white/90 backdrop-blur-sm rounded-lg px-2 py-1">
-        <span class="text-[10px] font-medium text-[#0f172a] uppercase tracking-wider"><%= article.category.name %></span>
-      </div>
-    </div>
-
-    <%# コンテンツ %>
-    <div class="p-5 flex flex-col gap-2">
-      <div class="flex items-center justify-between">
-        <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider"><%= article.year %>年</span>
-        <div class="flex items-center gap-1">
-          <svg class="size-3 text-[#94a3b8]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-          </svg>
-          <span class="text-xs text-[#94a3b8]">ヨーロッパ</span>
+<div class="relative">
+  <% if article.is_a?(Event) %>
+    <%= link_to event_path(article), class: "block" do %>
+    <div class="bg-white border border-[#e2e8f0] rounded-lg overflow-hidden hover:shadow-md transition-shadow">
+      <%# サムネイル %>
+      <div class="relative h-48 bg-[#f1f5f9]">
+        <% if article.image_url.present? %>
+          <%= image_tag article.image_url, class: "w-full h-full object-cover", alt: article.title %>
+        <% end %>
+        <div class="absolute top-3 left-3 bg-white/90 backdrop-blur-sm rounded-lg px-2 py-1">
+          <span class="text-[10px] font-medium text-[#0f172a] uppercase tracking-wider"><%= article.category.name %></span>
         </div>
       </div>
-      <h2 class="text-lg font-medium text-[#0f172a]"><%= article.title %></h2>
-      <p class="text-sm text-[#475569] line-clamp-2"><%= article.description %></p>
-    </div>
-  </div>
-  <% end %>
 
-<% elsif article.is_a?(Character) %>
-  <%= link_to character_path(article), class: "block" do %>
-  <div class="bg-white border border-[#e2e8f0] rounded-lg overflow-hidden hover:shadow-md transition-shadow">
-    <%# サムネイル %>
-    <div class="relative h-48 bg-[#f1f5f9]">
-      <% if article.image_url.present? %>
-        <%= image_tag article.image_url, class: "w-full h-full object-cover", alt: article.name %>
-      <% end %>
-      <div class="absolute top-3 left-3 bg-white/90 backdrop-blur-sm rounded-lg px-2 py-1">
-        <span class="text-[10px] font-medium text-[#0f172a] uppercase tracking-wider">人物</span>
+      <%# コンテンツ %>
+      <div class="p-5 flex flex-col gap-2">
+        <div class="flex items-center justify-between">
+          <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider"><%= article.year %>年</span>
+          <div class="flex items-center gap-1">
+            <svg class="size-3 text-[#94a3b8]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+            </svg>
+            <span class="text-xs text-[#94a3b8]">ヨーロッパ</span>
+          </div>
+        </div>
+        <h2 class="text-lg font-medium text-[#0f172a]"><%= article.title %></h2>
+        <p class="text-sm text-[#475569] line-clamp-2"><%= article.description %></p>
       </div>
     </div>
+    <% end %>
 
-    <%# コンテンツ %>
-    <div class="p-5 flex flex-col gap-2">
-      <div class="flex items-center justify-between">
-        <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider"><%= article.year %>年</span>
-        <div class="flex items-center gap-1">
-          <svg class="size-3 text-[#94a3b8]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-          </svg>
-          <span class="text-xs text-[#94a3b8]">イタリア</span>
+  <% elsif article.is_a?(Character) %>
+    <%= link_to character_path(article), class: "block" do %>
+    <div class="bg-white border border-[#e2e8f0] rounded-lg overflow-hidden hover:shadow-md transition-shadow">
+      <%# サムネイル %>
+      <div class="relative h-48 bg-[#f1f5f9]">
+        <% if article.image_url.present? %>
+          <%= image_tag article.image_url, class: "w-full h-full object-cover", alt: article.name %>
+        <% end %>
+        <div class="absolute top-3 left-3 bg-white/90 backdrop-blur-sm rounded-lg px-2 py-1">
+          <span class="text-[10px] font-medium text-[#0f172a] uppercase tracking-wider">人物</span>
         </div>
       </div>
-      <h2 class="text-lg font-medium text-[#0f172a]"><%= article.name %></h2>
-      <p class="text-sm text-[#475569] line-clamp-2"><%= article.description %></p>
+
+      <%# コンテンツ %>
+      <div class="p-5 flex flex-col gap-2">
+        <div class="flex items-center justify-between">
+          <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider"><%= article.year %>年</span>
+          <div class="flex items-center gap-1">
+            <svg class="size-3 text-[#94a3b8]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+            </svg>
+            <span class="text-xs text-[#94a3b8]">イタリア</span>
+          </div>
+        </div>
+        <h2 class="text-lg font-medium text-[#0f172a]"><%= article.name %></h2>
+        <p class="text-sm text-[#475569] line-clamp-2"><%= article.description %></p>
+      </div>
     </div>
-  </div>
+    <% end %>
   <% end %>
-<% end %>
+
+  <%# お気に入りボタン（リンクの外に配置） %>
+  <% if user_signed_in? %>
+    <div class="absolute top-3 right-3 z-10">
+      <%= render "shared/favorite_button", article: article %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -8,7 +8,12 @@
   <div class="absolute inset-0 opacity-90" style="background-image: linear-gradient(154deg, rgb(0, 11, 96) 0%, rgb(20, 34, 131) 100%)"></div>
   <div class="relative max-w-[1280px] mx-auto px-20 py-20 flex flex-col justify-center min-h-[500px]">
     <%# バッジ %>
-    <div class="pb-6">
+    <div class="pb-6 flex gap-3 items-center">
+      <% if user_signed_in? %>
+        <div class="mr-2">
+          <%= render "shared/favorite_button", article: @character %>
+        </div>
+      <% end %>
       <span class="inline-flex items-center gap-2 bg-[rgba(236,119,0,0.2)] rounded-full px-4 py-1.5">
         <svg class="w-3 h-3 text-[#ec7700]" fill="currentColor" viewBox="0 0 20 20">
           <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -8,7 +8,12 @@
   <div class="absolute inset-0 opacity-90" style="background-image: linear-gradient(154deg, rgb(0, 11, 96) 0%, rgb(20, 34, 131) 100%)"></div>
   <div class="relative max-w-[1280px] mx-auto px-20 py-20 flex flex-col justify-center min-h-[500px]">
     <%# カテゴリ・時代バッジ %>
-    <div class="pb-6 flex gap-3">
+    <div class="pb-6 flex gap-3 items-center">
+      <% if user_signed_in? %>
+        <div class="mr-2">
+          <%= render "shared/favorite_button", article: @event %>
+        </div>
+      <% end %>
       <span class="inline-flex items-center gap-2 bg-[rgba(236,119,0,0.2)] rounded-full px-4 py-1.5">
         <span class="text-xs font-semibold tracking-[1.2px] uppercase text-[#ec7700]"><%= @event.category.name %></span>
       </span>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,26 @@
+<div class="max-w-[1280px] mx-auto px-8 py-12">
+  <div class="mb-8">
+    <h1 class="text-[30px] font-medium text-[#0f172a]">お気に入り</h1>
+    <p class="text-[16px] text-[#64748b] mt-1"><%= @articles.total_count %>件の記事</p>
+  </div>
+
+  <% if @articles.any? %>
+    <div class="grid grid-cols-3 gap-6">
+      <% @articles.each do |article| %>
+        <%= render "articles/card", article: article %>
+      <% end %>
+    </div>
+
+    <div class="mt-8">
+      <%= paginate @articles, outer_window: 1, inner_window: 1, theme: "articles" %>
+    </div>
+  <% else %>
+    <div class="text-center py-20">
+      <svg class="mx-auto size-16 text-[#cbd5e1]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+      </svg>
+      <p class="text-[#64748b] mt-4 text-lg">お気に入りの記事はまだありません</p>
+      <%= link_to "記事一覧を見る", articles_path, class: "inline-block mt-4 text-[#3713ec] hover:underline" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_favorite_button.html.erb
+++ b/app/views/shared/_favorite_button.html.erb
@@ -1,0 +1,14 @@
+<% favorite = current_user.favorites.find_by(favorable: article) %>
+<% if favorite %>
+  <%= button_to favorite_path(favorite), method: :delete, class: "bg-white/90 backdrop-blur-sm rounded-full p-2 hover:bg-white transition" do %>
+    <svg class="size-5 text-red-500 fill-red-500" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+    </svg>
+  <% end %>
+<% else %>
+  <%= button_to favorites_path, params: { favorable_type: article.class.name, favorable_id: article.id }, class: "bg-white/90 backdrop-blur-sm rounded-full p-2 hover:bg-white transition" do %>
+    <svg class="size-5 text-[#94a3b8]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+    </svg>
+  <% end %>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -29,6 +29,7 @@
         </div>
       </div>
       <% if user_signed_in? %>
+        <%= link_to "お気に入り", favorites_path, class: "text-[14px] text-[#475569] font-medium hover:text-[#0f172a]" %>
         <%= link_to "#{current_user.name}さん", profile_path, class: "text-[14px] text-[#475569] font-medium hover:text-[#0f172a]" %>
         <%= button_to "ログアウト", destroy_user_session_path, method: :delete,
             class: "text-[14px] text-[#475569] font-medium hover:text-[#0f172a] cursor-pointer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   end
 
   get "profile", to: "profiles#show"
+  resources :favorites, only: [ :index, :create, :destroy ]
 
   resources :articles, only: [ :index ]
   resources :characters, only: [ :show ]

--- a/db/migrate/20260407052817_create_favorites.rb
+++ b/db/migrate/20260407052817_create_favorites.rb
@@ -1,0 +1,12 @@
+class CreateFavorites < ActiveRecord::Migration[7.2]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :favorable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :favorites, [ :user_id, :favorable_type, :favorable_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_07_010105) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_07_052817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_07_010105) do
     t.index ["study_unit_id"], name: "index_events_on_study_unit_id"
   end
 
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "favorable_type", null: false
+    t.bigint "favorable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["favorable_type", "favorable_id"], name: "index_favorites_on_favorable"
+    t.index ["user_id", "favorable_type", "favorable_id"], name: "index_favorites_on_user_id_and_favorable_type_and_favorable_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
   create_table "periods", force: :cascade do |t|
     t.string "name"
   end
@@ -93,4 +104,5 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_07_010105) do
   add_foreign_key "events", "periods"
   add_foreign_key "events", "regions"
   add_foreign_key "events", "study_units"
+  add_foreign_key "favorites", "users"
 end

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite do
+    user
+    association :favorable, factory: :event
+  end
+end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Favorite, type: :model do
+  describe "バリデーション" do
+    it "ユーザーとお気に入り対象があれば有効" do
+      favorite = build(:favorite)
+      expect(favorite).to be_valid
+    end
+
+    it "同じユーザーが同じ記事を重複登録できない" do
+      event = create(:event)
+      user = create(:user)
+      create(:favorite, user: user, favorable: event)
+      duplicate = build(:favorite, user: user, favorable: event)
+      expect(duplicate).not_to be_valid
+    end
+
+    it "異なるユーザーが同じ記事をお気に入りできる" do
+      event = create(:event)
+      create(:favorite, user: create(:user), favorable: event)
+      favorite = build(:favorite, user: create(:user), favorable: event)
+      expect(favorite).to be_valid
+    end
+
+    it "EventとCharacter両方をお気に入りできる" do
+      user = create(:user)
+      event_fav = create(:favorite, user: user, favorable: create(:event))
+      char_fav = build(:favorite, user: user, favorable: create(:character))
+      expect(event_fav).to be_valid
+      expect(char_fav).to be_valid
+    end
+  end
+end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Favorites", type: :request do
+  let(:user) { create(:user) }
+  let(:event) { create(:event) }
+  let(:character) { create(:character) }
+
+  describe "GET /favorites" do
+    context "ログイン済みの場合" do
+      before { sign_in user }
+
+      it "お気に入り一覧が表示される" do
+        get favorites_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "お気に入りした記事が表示される" do
+        create(:favorite, user: user, favorable: event)
+        get favorites_path
+        expect(response.body).to include(event.title)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログインページにリダイレクトされる" do
+        get favorites_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "POST /favorites" do
+    before { sign_in user }
+
+    it "Eventをお気に入りに追加できる" do
+      expect {
+        post favorites_path, params: { favorable_type: "Event", favorable_id: event.id }
+      }.to change(Favorite, :count).by(1)
+    end
+
+    it "Characterをお気に入りに追加できる" do
+      expect {
+        post favorites_path, params: { favorable_type: "Character", favorable_id: character.id }
+      }.to change(Favorite, :count).by(1)
+    end
+
+    it "同じ記事を重複登録できない" do
+      create(:favorite, user: user, favorable: event)
+      expect {
+        post favorites_path, params: { favorable_type: "Event", favorable_id: event.id }
+      }.not_to change(Favorite, :count)
+    end
+  end
+
+  describe "DELETE /favorites/:id" do
+    before { sign_in user }
+
+    it "お気に入りを解除できる" do
+      favorite = create(:favorite, user: user, favorable: event)
+      expect {
+        delete favorite_path(favorite)
+      }.to change(Favorite, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- ポリモーフィック関連のfavoritesテーブルでEvent/Character両方のお気に入りに対応
- 記事カード・詳細ページにお気に入りボタン（ハートアイコン）を配置
- お気に入り一覧ページ（`/favorites`）を作成
- ヘッダーにお気に入りリンクを追加（ログイン時のみ表示）

## Test plan
- [x] RSpecでモデル4件 + リクエスト7件 = 11テスト全通過
- [x] 記事一覧からお気に入り追加・解除の動作確認
- [x] 詳細ページからお気に入り追加・解除の動作確認
- [x] お気に入り一覧ページの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)