### PR TITLE
feat: 独自ドメイン(culturelink.jp)をhosts許可に追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,10 +96,11 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    "culturelink.jp",
+    "www.culturelink.jp",
+    /.*\.onrender\.com/
+  ]
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## Summary
- production環境の`config.hosts`に独自ドメイン`culturelink.jp`と`www.culturelink.jp`を追加
- Renderデフォルトドメイン(`*.onrender.com`)も併用可能なまま維持
- ヘルスチェックエンドポイント(`/up`)はDNS rebinding protection対象外に設定

## Test plan
- [ ] Renderデプロイ後、`https://culturelink.jp` でアクセスできることを確認
- [ ] `https://www.culturelink.jp` でアクセスできることを確認
- [ ] 既存のRenderドメインでも引き続きアクセスできることを確認
- [ ] `/up` ヘルスチェックが200を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)