### PR TITLE
refactor: schedule-paginationをcard-paginationにリネーム

### DIFF
--- a/app/javascript/controllers/card_pagination_controller.js
+++ b/app/javascript/controllers/card_pagination_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-// スケジュールカードのページネーション
+// カードのページネーション
 export default class extends Controller {
   static targets = ["page", "prevBtn", "nextBtn", "indicator"]
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,8 +19,8 @@ application.register("weekday-toggle", WeekdayToggleController)
 import UnitSelectController from "./unit_select_controller"
 application.register("unit-select", UnitSelectController)
 
-import SchedulePaginationController from "./schedule_pagination_controller"
-application.register("schedule-pagination", SchedulePaginationController)
+import CardPaginationController from "./card_pagination_controller"
+application.register("card-pagination", CardPaginationController)
 
 import QuizRunnerController from "./quiz_runner_controller"
 application.register("quiz-runner", QuizRunnerController)

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -78,25 +78,25 @@
   <div class="grid grid-cols-3 gap-8">
     <%# 今後の学習スケジュール（2カラム分） %>
     <div class="col-span-2">
-      <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm overflow-hidden" data-controller="schedule-pagination">
+      <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm overflow-hidden" data-controller="card-pagination">
         <%# ヘッダー %>
         <div class="flex items-center justify-between px-6 py-6 border-b border-[#f1f5f9]">
           <h2 class="text-[18px] font-medium text-[#0f172a]">今後の学習スケジュール</h2>
           <% if @schedules.any? %>
             <div class="flex items-center gap-3">
               <button class="p-1 rounded hover:bg-[#f1f5f9] disabled:opacity-30"
-                data-action="click->schedule-pagination#prev"
-                data-schedule-pagination-target="prevBtn">
+                data-action="click->card-pagination#prev"
+                data-card-pagination-target="prevBtn">
                 <svg class="w-5 h-5 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
                 </svg>
               </button>
-              <span class="text-[14px] font-semibold text-[#1e293b]" data-schedule-pagination-target="indicator">
+              <span class="text-[14px] font-semibold text-[#1e293b]" data-card-pagination-target="indicator">
                 1 / <%= @schedules.size %>
               </span>
               <button class="p-1 rounded hover:bg-[#f1f5f9] disabled:opacity-30"
-                data-action="click->schedule-pagination#next"
-                data-schedule-pagination-target="nextBtn">
+                data-action="click->card-pagination#next"
+                data-card-pagination-target="nextBtn">
                 <svg class="w-5 h-5 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                 </svg>
@@ -107,7 +107,7 @@
 
         <% if @schedules.any? %>
           <% @schedules.each_with_index do |schedule, i| %>
-            <div class="<%= 'hidden' unless i == 0 %>" data-schedule-pagination-target="page">
+            <div class="<%= 'hidden' unless i == 0 %>" data-card-pagination-target="page">
               <div class="flex flex-col gap-6 p-6">
                 <%# 学習期間 %>
                 <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- 学習履歴カードでも同じページネーション機能を再利用するため、Stimulus コントローラを汎用的な命名にリネーム
- `schedule_pagination_controller.js` → `card_pagination_controller.js`
- `controllers/index.js` の登録名と、`profiles/show.html.erb` の `data-controller` / `data-action` / `data-*-target` を一括更新
- 振る舞いの変更はなし（pure refactor）

## Test plan
- [x] rubocop 緑
- [x] `spec/requests/profiles_spec.rb` 緑
- [x] `yarn build` 成功
- [x] ブラウザでスケジュールカードのページネーション動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)