### PR TITLE
feat: 記事閲覧履歴機能を実装

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -1,5 +1,8 @@
 class CharactersController < ApplicationController
+  include ArticleViewable
+
   def show
     @character = Character.includes(:period, :region, :study_unit, events: [ :category, :period, :region ]).find(params[:id])
+    record_article_view(@character)
   end
 end

--- a/app/controllers/concerns/article_viewable.rb
+++ b/app/controllers/concerns/article_viewable.rb
@@ -5,9 +5,18 @@ module ArticleViewable
 
   def record_article_view(article)
     return unless user_signed_in?
+    # Turboのリンク先読み(prefetch)ではユーザーの閲覧意図がないため記録しない
+    return if prefetch_request?
 
     view = current_user.article_views.find_or_initialize_by(article: article)
     # 閲覧履歴の記録失敗で画面表示を壊さないため save!ではなくsaveを使用
     view.new_record? ? view.save : view.touch
+  end
+
+  # Turbo 8+ は X-Sec-Purpose、標準Fetchは Sec-Purpose を送る。両方をガード。
+  def prefetch_request?
+    %w[X-Sec-Purpose Sec-Purpose Purpose X-Purpose].any? do |name|
+      request.headers[name].to_s.include?("prefetch")
+    end
   end
 end

--- a/app/controllers/concerns/article_viewable.rb
+++ b/app/controllers/concerns/article_viewable.rb
@@ -1,0 +1,13 @@
+module ArticleViewable
+  extend ActiveSupport::Concern
+
+  private
+
+  def record_article_view(article)
+    return unless user_signed_in?
+
+    view = current_user.article_views.find_or_initialize_by(article: article)
+    # 閲覧履歴の記録失敗で画面表示を壊さないため save!ではなくsaveを使用
+    view.new_record? ? view.save : view.touch
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,8 @@
 class EventsController < ApplicationController
+  include ArticleViewable
+
   def show
     @event = Event.includes(:period, :category, :region, :study_unit, characters: [ :period, :region ]).find(params[:id])
+    record_article_view(@event)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,5 +8,9 @@ class ProfilesController < ApplicationController
       .includes(:quiz)
       .order(updated_at: :desc)
     @quiz_result_pages = @quiz_results.each_slice(3).to_a
+    @recent_article_views = current_user.article_views
+      .includes(:article)
+      .order(updated_at: :desc)
+      .limit(4)
   end
 end

--- a/app/models/article_view.rb
+++ b/app/models/article_view.rb
@@ -1,0 +1,6 @@
+class ArticleView < ApplicationRecord
+  belongs_to :user
+  belongs_to :article, polymorphic: true
+
+  validates :user_id, uniqueness: { scope: [ :article_type, :article_id ] }
+end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -5,6 +5,7 @@ class Character < ApplicationRecord
   has_many :event_characters
   has_many :events, through: :event_characters
   has_many :favorites, as: :favorable, dependent: :destroy
+  has_many :article_views, as: :article, dependent: :destroy
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,6 +6,7 @@ class Event < ApplicationRecord
   has_many :event_characters
   has_many :characters, through: :event_characters
   has_many :favorites, as: :favorable, dependent: :destroy
+  has_many :article_views, as: :article, dependent: :destroy
 
   validates :title, presence: true
   validates :year, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :schedules, dependent: :destroy
   has_many :quiz_results, dependent: :destroy
+  has_many :article_views, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,9 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%# Turboのリンク先読み(prefetch)を無効化: article_viewsの記録が実クリックと一致しないため %>
+    <meta name="turbo-prefetch" content="false">
+
 
     <%= yield :head %>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -229,73 +229,56 @@
           <h2 class="text-[18px] font-medium text-[#0f172a]">最近チェックした項目</h2>
         </div>
 
-        <div class="flex flex-col gap-6 p-6">
-          <%# ルネサンス期 %>
-          <div class="flex gap-4">
-            <div class="size-[64px] rounded-lg bg-[#e2e8f0] shrink-0 flex items-center justify-center">
-              <svg class="w-6 h-6 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/>
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-              </svg>
-            </div>
-            <div class="flex flex-col gap-1">
-              <p class="text-[14px] font-medium text-[#1e293b]">ルネサンス期</p>
-              <p class="text-[12px] text-[#64748b] pb-1">動画レッスン • 残り12分</p>
-              <div class="w-full h-1 bg-[#f1f5f9] rounded-full">
-                <div class="h-1 bg-[#3713ec] rounded-full" style="width: 67%"></div>
-              </div>
-            </div>
+        <% if @recent_article_views.any? %>
+          <div class="flex flex-col gap-6 p-6">
+            <% @recent_article_views.each do |view| %>
+              <% article = view.article %>
+              <% next unless article %>
+              <% if article.is_a?(Event) %>
+                <%= link_to event_path(article), class: "flex gap-4 hover:opacity-80 transition" do %>
+                  <div class="size-[64px] rounded-lg bg-[#e2e8f0] shrink-0 overflow-hidden flex items-center justify-center">
+                    <% if article.image_url.present? %>
+                      <%= image_tag article.image_url, class: "w-full h-full object-cover", alt: article.title %>
+                    <% else %>
+                      <svg class="w-6 h-6 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                      </svg>
+                    <% end %>
+                  </div>
+                  <div class="flex flex-col gap-1 min-w-0 flex-1">
+                    <p class="text-[14px] font-medium text-[#1e293b] truncate"><%= article.title %></p>
+                    <p class="text-[12px] text-[#64748b]">出来事 • <%= article.year %>年</p>
+                    <p class="text-[10px] text-[#94a3b8]"><%= l view.updated_at, format: :short %></p>
+                  </div>
+                <% end %>
+              <% elsif article.is_a?(Character) %>
+                <%= link_to character_path(article), class: "flex gap-4 hover:opacity-80 transition" do %>
+                  <div class="size-[64px] rounded-lg bg-[#e2e8f0] shrink-0 overflow-hidden flex items-center justify-center">
+                    <% if article.image_url.present? %>
+                      <%= image_tag article.image_url, class: "w-full h-full object-cover", alt: article.name %>
+                    <% else %>
+                      <svg class="w-6 h-6 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                      </svg>
+                    <% end %>
+                  </div>
+                  <div class="flex flex-col gap-1 min-w-0 flex-1">
+                    <p class="text-[14px] font-medium text-[#1e293b] truncate"><%= article.name %></p>
+                    <p class="text-[12px] text-[#64748b]">人物 • <%= article.year %>年</p>
+                    <p class="text-[10px] text-[#94a3b8]"><%= l view.updated_at, format: :short %></p>
+                  </div>
+                <% end %>
+              <% end %>
+            <% end %>
           </div>
-
-          <%# 中世キリスト教 %>
-          <div class="flex gap-4">
-            <div class="size-[64px] rounded-lg bg-[#e2e8f0] shrink-0 flex items-center justify-center">
-              <svg class="w-6 h-6 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
-              </svg>
-            </div>
-            <div class="flex flex-col gap-1">
-              <p class="text-[14px] font-medium text-[#1e293b]">中世キリスト教</p>
-              <p class="text-[12px] text-[#64748b]">練習用クイズ • 完了 9/10</p>
-              <p class="text-[10px] font-bold text-[#16a34a] uppercase">スコア: 90%</p>
-            </div>
+        <% else %>
+          <div class="flex flex-col items-center justify-center py-16 px-6">
+            <svg class="w-12 h-12 text-[#cbd5e1] mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+            </svg>
+            <p class="text-[14px] text-[#64748b] text-center">直近に確認した記事はありません</p>
           </div>
-
-          <%# ルネサンス %>
-          <div class="flex gap-4">
-            <div class="size-[64px] rounded-lg bg-[#e2e8f0] shrink-0 flex items-center justify-center">
-              <svg class="w-6 h-6 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
-              </svg>
-            </div>
-            <div class="flex flex-col gap-1">
-              <p class="text-[14px] font-medium text-[#1e293b]">ルネサンス</p>
-              <p class="text-[12px] text-[#64748b] pb-1">読解資料 • 残り5ページ</p>
-              <div class="w-full h-1 bg-[#f1f5f9] rounded-full">
-                <div class="h-1 bg-[#3713ec] rounded-full" style="width: 25%"></div>
-              </div>
-            </div>
-          </div>
-
-          <%# 近代ロマン主義革命 %>
-          <div class="flex gap-4">
-            <div class="size-[64px] rounded-lg bg-[#e2e8f0] shrink-0 flex items-center justify-center">
-              <svg class="w-6 h-6 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"/>
-              </svg>
-            </div>
-            <div class="flex flex-col gap-1">
-              <p class="text-[14px] font-medium text-[#1e293b]">近代ロマン主義革命</p>
-              <p class="text-[12px] text-[#64748b]">ポッドキャスト • 合計 45:00</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="border-t border-[#f1f5f9] px-4 py-4">
-          <div class="flex items-center justify-center py-2">
-            <span class="text-[14px] text-[#475569] cursor-pointer hover:text-[#0f172a]">すべての履歴を見る</span>
-          </div>
-        </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/db/migrate/20260413074322_create_article_views.rb
+++ b/db/migrate/20260413074322_create_article_views.rb
@@ -1,0 +1,13 @@
+class CreateArticleViews < ActiveRecord::Migration[7.2]
+  def change
+    create_table :article_views do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :article, polymorphic: true, null: false, index: false
+      t.timestamps
+    end
+
+    add_index :article_views, [ :article_type, :article_id ], name: "index_article_views_on_article"
+    add_index :article_views, [ :user_id, :article_type, :article_id ], unique: true, name: "index_article_views_on_user_and_article"
+    add_index :article_views, [ :user_id, :updated_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_12_102024) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_13_074322) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "article_views", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "article_type", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_type", "article_id"], name: "index_article_views_on_article"
+    t.index ["user_id", "article_type", "article_id"], name: "index_article_views_on_user_and_article", unique: true
+    t.index ["user_id", "updated_at"], name: "index_article_views_on_user_id_and_updated_at"
+    t.index ["user_id"], name: "index_article_views_on_user_id"
+  end
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
@@ -183,6 +195,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_102024) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "article_views", "users"
   add_foreign_key "characters", "periods"
   add_foreign_key "characters", "regions"
   add_foreign_key "characters", "study_units"

--- a/spec/factories/article_views.rb
+++ b/spec/factories/article_views.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :article_view do
+    association :user
+    association :article, factory: :event
+  end
+end

--- a/spec/models/article_view_spec.rb
+++ b/spec/models/article_view_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe ArticleView, type: :model do
+  describe "関連" do
+    it "userに属する" do
+      association = described_class.reflect_on_association(:user)
+      expect(association.macro).to eq(:belongs_to)
+    end
+
+    it "articleにpolymorphicで属する" do
+      association = described_class.reflect_on_association(:article)
+      expect(association.macro).to eq(:belongs_to)
+      expect(association.options[:polymorphic]).to be true
+    end
+  end
+
+  describe "バリデーション" do
+    let(:user) { create(:user) }
+    let(:event) { create(:event) }
+
+    it "user + article の組み合わせが一意であること" do
+      create(:article_view, user: user, article: event)
+      duplicate = build(:article_view, user: user, article: event)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:user_id]).to include("はすでに存在します")
+    end
+
+    it "別ユーザーが同じ記事を閲覧するのは許される" do
+      other_user = create(:user)
+      create(:article_view, user: user, article: event)
+      another = build(:article_view, user: other_user, article: event)
+      expect(another).to be_valid
+    end
+
+    it "同じユーザーが別記事を閲覧するのは許される" do
+      other_event = create(:event)
+      create(:article_view, user: user, article: event)
+      another = build(:article_view, user: user, article: other_event)
+      expect(another).to be_valid
+    end
+  end
+
+  describe "polymorphic対応" do
+    let(:user) { create(:user) }
+
+    it "Event を article として紐付けられる" do
+      event = create(:event)
+      view = create(:article_view, user: user, article: event)
+      expect(view.article).to eq(event)
+      expect(view.article_type).to eq("Event")
+    end
+
+    it "Character を article として紐付けられる" do
+      character = create(:character)
+      view = create(:article_view, user: user, article: character)
+      expect(view.article).to eq(character)
+      expect(view.article_type).to eq("Character")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,7 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [

--- a/spec/requests/characters_spec.rb
+++ b/spec/requests/characters_spec.rb
@@ -61,5 +61,46 @@ RSpec.describe "Characters", type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "閲覧履歴の記録" do
+      let(:user) { create(:user) }
+
+      context "ログイン中の場合" do
+        before { sign_in user }
+
+        it "閲覧するとarticle_viewが記録される" do
+          expect {
+            get character_path(character)
+          }.to change { ArticleView.count }.by(1)
+          view = ArticleView.last
+          expect(view.user).to eq(user)
+          expect(view.article).to eq(character)
+        end
+
+        it "同じ人物を複数回閲覧してもレコードは1件のまま" do
+          get character_path(character)
+          expect {
+            get character_path(character)
+          }.not_to change { ArticleView.count }
+        end
+
+        it "再閲覧時にupdated_atが更新される" do
+          get character_path(character)
+          first_updated_at = ArticleView.last.updated_at
+          travel_to 1.hour.from_now do
+            get character_path(character)
+          end
+          expect(ArticleView.last.updated_at).to be > first_updated_at
+        end
+      end
+
+      context "未ログインの場合" do
+        it "article_viewは記録されない" do
+          expect {
+            get character_path(character)
+          }.not_to change { ArticleView.count }
+        end
+      end
+    end
   end
 end

--- a/spec/requests/characters_spec.rb
+++ b/spec/requests/characters_spec.rb
@@ -101,6 +101,29 @@ RSpec.describe "Characters", type: :request do
           }.not_to change { ArticleView.count }
         end
       end
+
+      context "Turboのprefetchリクエストの場合" do
+        let(:user) { create(:user) }
+        before { sign_in user }
+
+        it "X-Sec-Purpose: prefetch が付いていると記録されない" do
+          expect {
+            get character_path(character), headers: { "X-Sec-Purpose" => "prefetch" }
+          }.not_to change { ArticleView.count }
+        end
+
+        it "Sec-Purpose: prefetch が付いていると記録されない" do
+          expect {
+            get character_path(character), headers: { "Sec-Purpose" => "prefetch" }
+          }.not_to change { ArticleView.count }
+        end
+
+        it "Purpose: prefetch が付いていると記録されない" do
+          expect {
+            get character_path(character), headers: { "Purpose" => "prefetch" }
+          }.not_to change { ArticleView.count }
+        end
+      end
     end
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -100,6 +100,29 @@ RSpec.describe "Events", type: :request do
           }.not_to change { ArticleView.count }
         end
       end
+
+      context "Turboのprefetchリクエストの場合" do
+        let(:user) { create(:user) }
+        before { sign_in user }
+
+        it "X-Sec-Purpose: prefetch が付いていると記録されない" do
+          expect {
+            get event_path(event), headers: { "X-Sec-Purpose" => "prefetch" }
+          }.not_to change { ArticleView.count }
+        end
+
+        it "Sec-Purpose: prefetch が付いていると記録されない" do
+          expect {
+            get event_path(event), headers: { "Sec-Purpose" => "prefetch" }
+          }.not_to change { ArticleView.count }
+        end
+
+        it "Purpose: prefetch が付いていると記録されない" do
+          expect {
+            get event_path(event), headers: { "Purpose" => "prefetch" }
+          }.not_to change { ArticleView.count }
+        end
+      end
     end
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -60,5 +60,46 @@ RSpec.describe "Events", type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "閲覧履歴の記録" do
+      let(:user) { create(:user) }
+
+      context "ログイン中の場合" do
+        before { sign_in user }
+
+        it "閲覧するとarticle_viewが記録される" do
+          expect {
+            get event_path(event)
+          }.to change { ArticleView.count }.by(1)
+          view = ArticleView.last
+          expect(view.user).to eq(user)
+          expect(view.article).to eq(event)
+        end
+
+        it "同じ記事を複数回閲覧してもレコードは1件のまま" do
+          get event_path(event)
+          expect {
+            get event_path(event)
+          }.not_to change { ArticleView.count }
+        end
+
+        it "再閲覧時にupdated_atが更新される" do
+          get event_path(event)
+          first_updated_at = ArticleView.last.updated_at
+          travel_to 1.hour.from_now do
+            get event_path(event)
+          end
+          expect(ArticleView.last.updated_at).to be > first_updated_at
+        end
+      end
+
+      context "未ログインの場合" do
+        it "article_viewは記録されない" do
+          expect {
+            get event_path(event)
+          }.not_to change { ArticleView.count }
+        end
+      end
+    end
   end
 end

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -24,6 +24,61 @@ RSpec.describe "Profiles", type: :request do
         expect(response.body).to include("おかえりなさい")
       end
 
+      describe "最近チェックした項目" do
+        context "閲覧履歴がある場合" do
+          let!(:old_event) { create(:event, title: "古い出来事") }
+          let!(:new_event) { create(:event, title: "新しい出来事") }
+          let!(:character) { create(:character, name: "登場人物A") }
+
+          before do
+            create(:article_view, user: user, article: old_event, updated_at: 3.days.ago)
+            create(:article_view, user: user, article: new_event, updated_at: 1.hour.ago)
+            create(:article_view, user: user, article: character, updated_at: 1.day.ago)
+          end
+
+          it "閲覧したEventとCharacterが両方表示される" do
+            get profile_path
+            expect(response.body).to include("古い出来事")
+            expect(response.body).to include("新しい出来事")
+            expect(response.body).to include("登場人物A")
+          end
+
+          it "最新閲覧順(updated_at DESC)に並ぶ" do
+            get profile_path
+            new_pos = response.body.index("新しい出来事")
+            char_pos = response.body.index("登場人物A")
+            old_pos = response.body.index("古い出来事")
+            expect(new_pos).to be < char_pos
+            expect(char_pos).to be < old_pos
+          end
+
+          it "他ユーザーの閲覧履歴は表示されない" do
+            other_user = create(:user)
+            other_event = create(:event, title: "他人の出来事")
+            create(:article_view, user: other_user, article: other_event)
+            get profile_path
+            expect(response.body).not_to include("他人の出来事")
+          end
+
+          it "最大4件まで表示される" do
+            5.times do |i|
+              event = create(:event, title: "イベント#{i}")
+              create(:article_view, user: user, article: event, updated_at: (i + 10).hours.ago)
+            end
+            get profile_path
+            # 最古の1件(3日前の「古い出来事")は4件制限で切られる想定
+            expect(response.body).not_to include("古い出来事")
+          end
+        end
+
+        context "閲覧履歴がない場合" do
+          it "空状態メッセージが表示される" do
+            get profile_path
+            expect(response.body).to include("直近に確認した記事はありません")
+          end
+        end
+      end
+
       describe "学習履歴カード" do
         context "受験済みのクイズがある場合" do
           let!(:completed_quiz) { create(:quiz, title: "ルネサンスのクイズ") }


### PR DESCRIPTION
## Summary
- 記事(Event / Character)の閲覧履歴を記録する `article_views` テーブルを新規追加
- ログイン中ユーザーが記事を閲覧すると自動で履歴を記録(polymorphic)
- プロフィール画面の「最近チェックした項目」を実データに差し替え
- 同一記事を複数回閲覧しても1レコードのまま `updated_at` だけ更新され、最新閲覧順に並ぶ
- 閲覧履歴が0件のときは「直近に確認した記事はありません」を表示

## 設計
- **DB**: polymorphic (`article_type` / `article_id`) + `[user_id, article_type, article_id]` 複合ユニーク制約で1ユーザー1記事1レコードを保証
- **記録ロジック**: `ArticleViewable` concern を `EventsController` / `CharactersController` に include
- **`viewed_at`は作らず `updated_at` 流用**: 過剰設計を避けるシンプル構成
- **取得**: `updated_at DESC`, `limit(4)` で最新4件
- **Turboのprefetch対応**: 
  - hover時のprefetchで閲覧履歴が汚染される問題を確認
  - concernで `X-Sec-Purpose: prefetch` 等のヘッダーをガード
  - layout に `<meta name="turbo-prefetch" content="false">` を追加し、prefetchキャッシュと実クリックの不一致を防止

## コミット
1. `feat: article_viewsテーブル・モデルを追加` — migration / model / 関連 / model spec
2. `feat: 記事閲覧時に閲覧履歴を記録する仕組みを追加` — Concern / controller / request spec
3. `feat: プロフィール画面に最近チェックした記事を実装` — profiles#show / view / 空状態 / request spec
4. `fix: Turboのprefetchで閲覧履歴が誤記録される問題を修正` — prefetchガード / 無効化

## Test plan
- [x] `spec/models/article_view_spec.rb` 追加 (関連 / validation / polymorphic)
- [x] `spec/requests/events_spec.rb` / `characters_spec.rb` に閲覧履歴記録テスト追加
- [x] `spec/requests/profiles_spec.rb` に「最近チェックした項目」テスト追加
- [x] 全テスト緑 (250 examples, 0 failures)
- [x] rubocop 緑
- [x] ブラウザ動作確認済み
  - [x] ホバーだけでは履歴に記録されない
  - [x] 実クリックで履歴に記録される
  - [x] Event / Character 両対応
  - [x] 同一記事再閲覧で順序が更新される
  - [x] 4件を超えると古いものが切られる
  - [x] 0件時は空状態メッセージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)