### PR TITLE
feat: プライバシーポリシーと利用規約ページを追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
   def top; end
+  def privacy; end
+  def terms; end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -36,6 +36,14 @@
         <%= f.submit "会員登録",
             class: "w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition cursor-pointer font-medium" %>
       </div>
+
+      <p class="text-xs text-gray-500 text-center mb-2">
+        会員登録することで、
+        <%= link_to "利用規約", terms_path, class: "text-blue-600 hover:underline" %>
+        および
+        <%= link_to "プライバシーポリシー", privacy_path, class: "text-blue-600 hover:underline" %>
+        に同意したものとみなします。
+      </p>
     <% end %>
 
     <%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -26,6 +26,14 @@
         <%= f.submit "ログイン",
             class: "w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition cursor-pointer font-medium" %>
       </div>
+
+      <p class="text-xs text-gray-500 text-center mb-2">
+        ログインすることで、
+        <%= link_to "利用規約", terms_path, class: "text-blue-600 hover:underline" %>
+        および
+        <%= link_to "プライバシーポリシー", privacy_path, class: "text-blue-600 hover:underline" %>
+        に同意したものとみなします。
+      </p>
     <% end %>
 
     <%= render "devise/shared/links" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -14,9 +14,9 @@
       </div>
 
       <nav class="flex items-center gap-6">
-        <%= link_to "プライバシー", "#", class: "text-[14px] text-[#94a3b8] font-medium hover:text-white" %>
-        <%= link_to "利用規約", "#", class: "text-[14px] text-[#94a3b8] font-medium hover:text-white" %>
-        <%= link_to "お問い合わせ", "#", class: "text-[14px] text-[#94a3b8] font-medium hover:text-white" %>
+        <%= link_to "プライバシー", privacy_path, class: "text-[14px] text-[#94a3b8] font-medium hover:text-white" %>
+        <%= link_to "利用規約", terms_path, class: "text-[14px] text-[#94a3b8] font-medium hover:text-white" %>
+        <%= mail_to "supportculturelink@gmail.com", "お問い合わせ", class: "text-[14px] text-[#94a3b8] font-medium hover:text-white" %>
       </nav>
     </div>
 

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,166 @@
+<% content_for(:title, "プライバシーポリシー | culture-link") %>
+
+<div class="bg-[#f8fafc] w-full min-h-screen">
+  <div class="max-w-4xl mx-auto px-6 py-20">
+    <%# ヘッダー %>
+    <div class="flex flex-col gap-4 mb-12">
+      <h1 class="text-4xl md:text-5xl font-bold text-[#0f172a] tracking-tight">
+        プライバシーポリシー
+      </h1>
+      <p class="text-base text-[#64748b]">最終更新日: 2026年4月15日</p>
+      <div class="bg-[#3713ec] h-1 w-20 rounded-full"></div>
+    </div>
+
+    <%# 本文カード %>
+    <div class="bg-white border border-[rgba(55,19,236,0.05)] rounded-xl shadow-sm p-8 md:p-10">
+      <p class="text-[#475569] text-[17px] leading-relaxed mb-10">
+        culture-link（以下、「当社」といいます。）は、本ウェブサイト上で提供するサービス（以下、「本サービス」といいます。）における、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下、「本ポリシー」といいます。）を定めます。
+      </p>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第1条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（個人情報）</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed">
+          「個人情報」とは、個人情報保護法にいう「個人情報」を指すものとし、生存する個人に関する情報であって、氏名、生年月日、住所、電話番号、連絡先その他の記述等により特定の個人を識別できる情報を指します。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第2条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（個人情報の収集方法）</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed">
+          当社は、ユーザーが利用登録をする際に、氏名、メールアドレス、パスワード等の個人情報をお知らせいただくことがあります。また、提携先などから取引記録や決済情報を収集することがあります。なお、本サービスでは、通信の安全性を確保するため、SSL（Secure Sockets Layer）等の暗号化技術を用いて個人情報の保護に努めています。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第3条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（個人情報を収集・利用する目的）</h2>
+        </div>
+        <ul class="list-disc list-inside text-[#475569] text-[17px] leading-relaxed space-y-2 pl-2">
+          <li>本サービスの提供・運営のため</li>
+          <li>お問い合わせへの対応（本人確認を含む）</li>
+          <li>新機能・更新情報・キャンペーン等の案内</li>
+          <li>メンテナンスや重要なお知らせの通知</li>
+          <li>不正利用防止および利用制限のため</li>
+          <li>登録情報の閲覧・変更・削除のため</li>
+          <li>上記目的に付随する目的</li>
+        </ul>
+      </section>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第4条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">(利用目的の変更)</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed">
+          当社は、変更前と関連性を有すると合理的に認められる場合に限り、個人情報の利用目的を変更するものとします。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第5条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（個人情報の第三者提供）</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed mb-3">
+          当社は、次に掲げる場合を除き、あらかじめユーザーの同意を得ることなく、第三者に個人情報を提供することはありません。
+        </p>
+        <ul class="list-disc list-inside text-[#475569] text-[17px] leading-relaxed space-y-2 pl-2">
+          <li>法令に基づく場合</li>
+          <li>人の生命・身体・財産の保護が必要な場合</li>
+          <li>公衆衛生・児童の健全育成のために必要な場合</li>
+          <li>国・地方公共団体への協力が必要な場合</li>
+        </ul>
+      </section>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第6条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（個人情報の開示）</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed">
+          本人から個人情報の開示を求められた場合には、本人確認の上、遅滞なく対応します。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第7条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（訂正および削除）</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed">
+          ユーザーは、自己の個人情報が誤っている場合、当社所定の手続きにより訂正・削除を請求できます。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第8条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（利用停止等）</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed">
+          利用目的外での取扱いや不正取得が判明した場合、当社は調査の上、必要に応じて利用停止等を行います。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第9条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（本ポリシーの変更）</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed">
+          本ポリシーは、ユーザーに通知することなく変更されることがあります。変更後の内容は、本サイト掲載時点で効力を生じます。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="flex items-center gap-2 mb-4">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第10条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（Cookieおよび外部送信について）</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed">
+          本サービスでは、利用状況の分析や利便性向上のため、Cookie（クッキー）を使用し、Google Analytics等の外部サービスを利用することがあります。これにより収集されるデータは匿名であり、個人を特定するものではありません。ユーザーはブラウザの設定によりCookieを無効にすることができます。
+        </p>
+      </section>
+
+      <section>
+        <div class="flex items-center gap-2 mb-6">
+          <span class="text-2xl font-bold text-[rgba(55,19,236,0.6)]">第11条</span>
+          <h2 class="text-2xl font-bold text-[#0f172a]">（お問い合わせ）</h2>
+        </div>
+        <p class="text-[#475569] text-[17px] leading-relaxed mb-4">
+          本ポリシーに関するお問い合わせは、下記の窓口までお願いいたします。
+        </p>
+        <div class="bg-[rgba(55,19,236,0.05)] border border-[rgba(55,19,236,0.1)] rounded-lg p-6">
+          <p class="text-[#1e293b] text-[17px] font-medium mb-2">
+            culture-link プライバシー管理事務局
+          </p>
+          <div class="flex items-center gap-2">
+            <svg class="w-4 h-4 text-[#3713ec]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+            </svg>
+            <a href="mailto:supportculturelink@gmail.com" class="text-[#0f172a] text-sm hover:underline">
+              supportculturelink@gmail.com
+            </a>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <%# ホームに戻るボタン %>
+    <div class="flex justify-center mt-10">
+      <%= link_to root_path, class: "bg-[#3713ec] text-white px-10 py-3 rounded-xl shadow-[0px_10px_15px_-3px_rgba(55,19,236,0.2),0px_4px_6px_-4px_rgba(55,19,236,0.2)] flex items-center gap-2 hover:opacity-90 transition" do %>
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+        </svg>
+        <span class="text-base">ホームに戻る</span>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,110 @@
+<% content_for(:title, "利用規約 | culture-link") %>
+
+<div class="bg-[#f8fafc] w-full min-h-screen">
+  <div class="max-w-4xl mx-auto px-6 py-20">
+    <%# ヘッダー（センター寄せ） %>
+    <div class="flex flex-col items-center gap-4 mb-12">
+      <h1 class="text-4xl md:text-5xl font-bold text-[#0f172a] text-center">
+        利用規約
+      </h1>
+      <span class="bg-[#f1f5f9] text-[#64748b] text-sm font-medium px-4 py-1.5 rounded-full">
+        最終更新日: 2026年4月15日
+      </span>
+    </div>
+
+    <%# 本文カード %>
+    <div class="bg-white border border-[#f1f5f9] rounded-2xl shadow-[0px_20px_25px_-5px_rgba(226,232,240,0.5),0px_8px_10px_-6px_rgba(226,232,240,0.5)] p-8 md:p-12">
+      <p class="text-[#334155] text-base leading-[26px] mb-10">
+        culture-link（以下、「当社」といいます。）は、本ウェブサイト上で提供するサービス（以下、「本サービス」といいます。）に関する利用規約（以下、「本規約」といいます。）を定めます。
+      </p>
+
+      <section class="mb-10">
+        <div class="border-l-4 border-[#3713ec] pl-5 mb-6">
+          <h2 class="text-2xl font-bold text-[#0f172a]">第1条（適用）</h2>
+        </div>
+        <p class="text-[#334155] text-base leading-[26px]">
+          本規約は、利用者と当社との間の本サービスの利用に関わる一切の関係に適用されるものとします。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="border-l-4 border-[#3713ec] pl-5 mb-6">
+          <h2 class="text-2xl font-bold text-[#0f172a]">第2条（禁止事項）</h2>
+        </div>
+        <p class="text-[#334155] text-base leading-[26px] mb-4">
+          利用者は、本サービスの利用にあたり、以下の行為をしてはなりません。
+        </p>
+        <ul class="list-disc list-inside text-[#334155] text-base leading-[26px] space-y-2 pl-2">
+          <li>法令または公序良俗に違反する行為</li>
+          <li>本サービスの内容（歴史データ、画像、デザイン等）を無断で転載、複製、または二次利用する行為</li>
+          <li>当社のサーバーまたはネットワークの機能を破壊したり、妨害したりする行為</li>
+          <li>本サービスの運営を妨害するおそれのある行為</li>
+          <li>その他、当社が不適切と判断する行為</li>
+        </ul>
+      </section>
+
+      <section class="mb-10">
+        <div class="border-l-4 border-[#3713ec] pl-5 mb-6">
+          <h2 class="text-2xl font-bold text-[#0f172a]">第3条（知的財産権）</h2>
+        </div>
+        <p class="text-[#334155] text-base leading-[26px]">
+          本サービスに含まれる文章・画像・プログラム等の著作権およびその他の知的財産権は、すべて当社または権利者に帰属します。利用者は、これらを私的使用の範囲を超えて利用することはできません。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="border-l-4 border-[#3713ec] pl-5 mb-6">
+          <h2 class="text-2xl font-bold text-[#0f172a]">第4条（本サービスの提供の停止等）</h2>
+        </div>
+        <p class="text-[#334155] text-base leading-[26px] mb-4">
+          当社は、以下のいずれかの事由があると判断した場合、利用者に事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
+        </p>
+        <ul class="list-disc list-inside text-[#334155] text-base leading-[26px] space-y-2 pl-2">
+          <li>本サービスに係るコンピュータシステムの保守点検または更新を行う場合</li>
+          <li>天災などの不可抗力により、本サービスの提供が困難となった場合</li>
+          <li>その他、当社が停止を必要と判断した場合</li>
+        </ul>
+      </section>
+
+      <section class="mb-10">
+        <div class="border-l-4 border-[#3713ec] pl-5 mb-6">
+          <h2 class="text-2xl font-bold text-[#0f172a]">第5条（免責事項）</h2>
+        </div>
+        <p class="text-[#334155] text-base leading-[26px] mb-3">
+          当社は、本サービスの内容（歴史的情報の正確性や完全性等を含む）について、明示的にも黙示的にも保証するものではありません。
+        </p>
+        <p class="text-[#334155] text-base leading-[26px]">
+          当社は、本サービスの利用により利用者に生じたあらゆる損害について、一切の責任を負いません。
+        </p>
+      </section>
+
+      <section class="mb-10">
+        <div class="border-l-4 border-[#3713ec] pl-5 mb-6">
+          <h2 class="text-2xl font-bold text-[#0f172a]">第6条（サービス内容の変更・終了）</h2>
+        </div>
+        <p class="text-[#334155] text-base leading-[26px]">
+          当社は、利用者に通知することなく、本サービスの内容を変更し、または提供を終了することができるものとします。
+        </p>
+      </section>
+
+      <section>
+        <div class="border-l-4 border-[#3713ec] pl-5 mb-6">
+          <h2 class="text-2xl font-bold text-[#0f172a]">第7条（利用規約の変更）</h2>
+        </div>
+        <p class="text-[#334155] text-base leading-[26px]">
+          当社は、必要と判断した場合には、いつでも本規約を変更することができるものとします。
+        </p>
+      </section>
+    </div>
+
+    <%# ホームに戻るボタン %>
+    <div class="flex justify-center mt-10">
+      <%= link_to root_path, class: "bg-[#3713ec] text-white px-10 py-3 rounded-xl shadow-[0px_10px_15px_-3px_rgba(55,19,236,0.2),0px_4px_6px_-4px_rgba(55,19,236,0.2)] flex items-center gap-2 hover:opacity-90 transition" do %>
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+        </svg>
+        <span class="text-base">ホームに戻る</span>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 
+  get "privacy", to: "static_pages#privacy"
+  get "terms", to: "static_pages#terms"
   get "profile", to: "profiles#show"
   resources :favorites, only: [ :index, :create, :destroy ]
   resources :schedules, only: [ :new, :create, :edit, :update, :destroy ]

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "StaticPages", type: :request do
+  describe "GET /privacy" do
+    it "プライバシーポリシーページが正常に表示される" do
+      get privacy_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("プライバシーポリシー")
+      expect(response.body).to include("culture-link")
+      expect(response.body).to include("第1条")
+      expect(response.body).to include("supportculturelink@gmail.com")
+    end
+  end
+
+  describe "GET /terms" do
+    it "利用規約ページが正常に表示される" do
+      get terms_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("利用規約")
+      expect(response.body).to include("culture-link")
+      expect(response.body).to include("第1条（適用）")
+      expect(response.body).to include("第7条（利用規約の変更）")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `/privacy` と `/terms` の静的ページを実装
- LINE Loginのメールアドレス取得権限申請に必要なプライバシーポリシー明示に対応
- フッターのプレースホルダーリンクを実パスに差し替え
- 会員登録/ログイン画面に同意文言を追加

## デザイン
Figmaデザインをベースにしつつ、既存のプライマリカラー `#3713ec`（紫）に統一:
- **プライバシーポリシー**: 左寄せタイトル + アンダーライン + インライン番号見出し
- **利用規約**: 中央寄せタイトル + pillバッジ + 左ボーダー型見出し
- 両ページ末尾にホームに戻るボタン

## コンテンツ
- プライバシーポリシー: 全11条（条文形式）
- 利用規約: 全7条（条文形式）
- 最終更新日: 2026年4月15日
- お問い合わせ先: supportculturelink@gmail.com
- ブランド表記: culture-link で統一

## Test plan
- [x] `/privacy` が200を返し、期待する文言を含むこと
- [x] `/terms` が200を返し、期待する文言を含むこと
- [x] 全RSpec Green (259 examples, 0 failures)
- [x] rubocop クリーン
- [ ] デザイン確認(画面で確認済み)
- [ ] フッターのリンクから両ページに遷移できること
- [ ] 会員登録/ログイン画面の同意文言からも両ページに遷移できること

## 次のステップ
このPRマージ後、LINE Developers Consoleでメールアドレス取得権限を申請する。プライバシーポリシー(第2条・第3条)でメアド収集・利用目的を明示しているので、申請時のスクリーンショット要件を満たせるはず。

🤖 Generated with [Claude Code](https://claude.com/claude-code)