### PR TITLE
feat: アカウント設定ページ（退会・パスワード変更）を実装

### DIFF
--- a/app/controllers/account/passwords_controller.rb
+++ b/app/controllers/account/passwords_controller.rb
@@ -1,0 +1,23 @@
+class Account::PasswordsController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    unless current_user.password_changeable?
+      redirect_to account_path, alert: "このアカウントではパスワードを変更できません"
+      return
+    end
+
+    if current_user.update_with_password(password_params)
+      bypass_sign_in(current_user)
+      redirect_to account_path, notice: "パスワードを変更しました"
+    else
+      render "accounts/show", status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def password_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,6 @@
+class AccountsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,4 +1,22 @@
 class Users::RegistrationsController < Devise::RegistrationsController
+  DELETION_CONFIRMATION_TEXT = "退会".freeze
+
+  def destroy
+    if resource.password_changeable?
+      unless resource.valid_password?(params.dig(:user, :current_password).to_s)
+        redirect_to account_path, alert: "現在のパスワードが正しくありません"
+        return
+      end
+    else
+      unless params.dig(:user, :deletion_confirmation) == DELETION_CONFIRMATION_TEXT
+        redirect_to account_path, alert: "確認のため「#{DELETION_CONFIRMATION_TEXT}」と入力してください"
+        return
+      end
+    end
+
+    super
+  end
+
   protected
 
   def update_resource(resource, params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,4 +32,8 @@ class User < ApplicationRecord
   def password_required?
     super && provider.blank?
   end
+
+  def password_changeable?
+    provider.blank?
+  end
 end

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,0 +1,93 @@
+<div class="max-w-[720px] mx-auto px-8 py-12">
+  <div class="mb-8">
+    <h1 class="text-[30px] font-medium text-[#0f172a]">アカウント設定</h1>
+    <p class="text-[16px] text-[#64748b] mt-1">パスワードの変更や退会の手続きができます。</p>
+  </div>
+
+  <%# プロフィール編集への導線 %>
+  <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-6 mb-6">
+    <h2 class="text-[18px] font-medium text-[#0f172a] mb-2">プロフィール情報</h2>
+    <p class="text-[14px] text-[#64748b] mb-4">ニックネームやメールアドレスを変更できます。</p>
+    <%= link_to edit_user_registration_path, class: "inline-flex items-center gap-2 bg-white border border-[#e2e8f0] text-[#475569] text-[14px] font-medium px-4 py-2 rounded-lg hover:bg-[#f8fafc] transition" do %>
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+      </svg>
+      プロフィールを編集する
+    <% end %>
+  </div>
+
+  <%# パスワード変更（通常ユーザーのみ） %>
+  <% if current_user.password_changeable? %>
+    <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-6 mb-6">
+      <h2 class="text-[18px] font-medium text-[#0f172a] mb-2">パスワード変更</h2>
+      <p class="text-[14px] text-[#64748b] mb-6">現在のパスワードを入力してから、新しいパスワードを設定してください。</p>
+
+      <%= form_with(model: current_user, url: account_password_path, method: :patch, scope: :user, html: { class: "flex flex-col gap-4" }) do |f| %>
+        <% if current_user.errors.any? %>
+          <div class="bg-[#fef2f2] border border-[#fecaca] text-[#991b1b] text-[14px] rounded-lg px-4 py-3">
+            <ul class="list-disc pl-5">
+              <% current_user.errors.full_messages.each do |msg| %>
+                <li><%= msg %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <div class="flex flex-col gap-1">
+          <%= f.label :current_password, "現在のパスワード", class: "text-[14px] font-medium text-[#0f172a]" %>
+          <%= f.password_field :current_password, autocomplete: "current-password", required: true,
+              class: "border border-[#e2e8f0] rounded-lg px-4 py-2 text-[14px] focus:outline-none focus:border-[#3713ec]" %>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <%= f.label :password, "新しいパスワード", class: "text-[14px] font-medium text-[#0f172a]" %>
+          <%= f.password_field :password, autocomplete: "new-password", required: true,
+              class: "border border-[#e2e8f0] rounded-lg px-4 py-2 text-[14px] focus:outline-none focus:border-[#3713ec]" %>
+          <p class="text-[12px] text-[#94a3b8]">6文字以上で入力してください。</p>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "text-[14px] font-medium text-[#0f172a]" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true,
+              class: "border border-[#e2e8f0] rounded-lg px-4 py-2 text-[14px] focus:outline-none focus:border-[#3713ec]" %>
+        </div>
+
+        <div>
+          <%= f.submit "パスワードを変更する",
+              class: "bg-gradient-to-r from-[#3713ec] to-[#5b3ff0] text-white text-[14px] font-medium px-6 py-3 rounded-full shadow-[0px_8px_10px_-6px_rgba(55,19,236,0.2)] hover:opacity-90 transition cursor-pointer" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%# 退会 %>
+  <div class="bg-white border border-[#fecaca] rounded-lg shadow-sm p-6">
+    <h2 class="text-[18px] font-medium text-[#991b1b] mb-2">退会する</h2>
+    <p class="text-[14px] text-[#64748b] mb-6">
+      退会するとアカウントと関連データ（お気に入り、学習スケジュール、クイズ結果など）がすべて削除されます。この操作は取り消せません。
+    </p>
+
+    <%= form_with(url: user_registration_path, method: :delete, scope: :user, html: { class: "flex flex-col gap-4", data: { turbo_confirm: "本当に退会しますか？この操作は取り消せません。" } }) do |f| %>
+      <% if current_user.password_changeable? %>
+        <div class="flex flex-col gap-1">
+          <%= f.label :current_password, "現在のパスワード", class: "text-[14px] font-medium text-[#0f172a]" %>
+          <%= f.password_field :current_password, autocomplete: "current-password", required: true,
+              class: "border border-[#e2e8f0] rounded-lg px-4 py-2 text-[14px] focus:outline-none focus:border-[#ef4444]" %>
+          <p class="text-[12px] text-[#94a3b8]">確認のため、現在のパスワードを入力してください。</p>
+        </div>
+      <% else %>
+        <div class="flex flex-col gap-1">
+          <%= f.label :deletion_confirmation, "確認入力", class: "text-[14px] font-medium text-[#0f172a]" %>
+          <%= f.text_field :deletion_confirmation, required: true, placeholder: "退会",
+              class: "border border-[#e2e8f0] rounded-lg px-4 py-2 text-[14px] focus:outline-none focus:border-[#ef4444]" %>
+          <p class="text-[12px] text-[#94a3b8]">確認のため「退会」と入力してください。</p>
+        </div>
+      <% end %>
+
+      <div>
+        <%= f.submit "退会する",
+            class: "bg-[#ef4444] text-white text-[14px] font-medium px-6 py-3 rounded-full shadow-[0px_8px_10px_-6px_rgba(239,68,68,0.3)] hover:opacity-90 transition cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -9,12 +9,21 @@
         順調ですね！今日は3つの学習セッションが予定されています。
       </p>
     </div>
-    <%= link_to edit_user_registration_path, class: "flex items-center gap-2 bg-white border border-[#e2e8f0] text-[#475569] text-[14px] font-medium px-4 py-2 rounded-lg hover:bg-[#f8fafc] transition shrink-0" do %>
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
-      </svg>
-      プロフィール編集
-    <% end %>
+    <div class="flex items-center gap-3 shrink-0">
+      <%= link_to edit_user_registration_path, class: "flex items-center gap-2 bg-white border border-[#e2e8f0] text-[#475569] text-[14px] font-medium px-4 py-2 rounded-lg hover:bg-[#f8fafc] transition" do %>
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+        </svg>
+        プロフィール編集
+      <% end %>
+      <%= link_to account_path, class: "flex items-center gap-2 bg-white border border-[#e2e8f0] text-[#475569] text-[14px] font-medium px-4 py-2 rounded-lg hover:bg-[#f8fafc] transition" do %>
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+        </svg>
+        アカウント設定
+      <% end %>
+    </div>
   </div>
 
   <%# 学習履歴カード %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
   get "privacy", to: "static_pages#privacy"
   get "terms", to: "static_pages#terms"
   get "profile", to: "profiles#show"
+  get "account", to: "accounts#show"
+  namespace :account do
+    resource :password, only: [ :update ]
+  end
   resources :favorites, only: [ :index, :create, :destroy ]
   resources :schedules, only: [ :new, :create, :edit, :update, :destroy ]
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
     sequence(:email) { |n| "user#{n}@example.com" }
     password { "password123" }
     password_confirmation { "password123" }
+
+    trait :google_user do
+      provider { "google_oauth2" }
+      sequence(:uid) { |n| "google-uid-#{n}" }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -92,6 +92,18 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#password_changeable?" do
+    it "通常ユーザーはtrueを返す" do
+      user = build(:user)
+      expect(user.password_changeable?).to be true
+    end
+
+    it "OAuth連携ユーザーはfalseを返す" do
+      user = build(:user, :google_user)
+      expect(user.password_changeable?).to be false
+    end
+  end
+
   describe "#password_required?" do
     context "OAuth経由のユーザー(providerあり)の場合" do
       it "パスワードなしでも保存できる" do

--- a/spec/requests/account/passwords_spec.rb
+++ b/spec/requests/account/passwords_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe "Account::Passwords", type: :request do
+  describe "PATCH /account/password" do
+    context "未ログインの場合" do
+      it "ログインページにリダイレクトされる" do
+        patch account_password_path, params: { user: { current_password: "password123", password: "newpassword456", password_confirmation: "newpassword456" } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "通常ユーザーでログイン中" do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it "現在のパスワードが正しければパスワードを変更できる" do
+        patch account_password_path, params: {
+          user: {
+            current_password: "password123",
+            password: "newpassword456",
+            password_confirmation: "newpassword456"
+          }
+        }
+        expect(user.reload.valid_password?("newpassword456")).to be true
+      end
+
+      it "変更成功時はアカウント設定ページにリダイレクトされる" do
+        patch account_password_path, params: {
+          user: {
+            current_password: "password123",
+            password: "newpassword456",
+            password_confirmation: "newpassword456"
+          }
+        }
+        expect(response).to redirect_to(account_path)
+      end
+
+      it "現在のパスワードが間違っていれば変更されない" do
+        patch account_password_path, params: {
+          user: {
+            current_password: "wrongpassword",
+            password: "newpassword456",
+            password_confirmation: "newpassword456"
+          }
+        }
+        expect(user.reload.valid_password?("password123")).to be true
+      end
+
+      it "新しいパスワードと確認が一致しなければ変更されない" do
+        patch account_password_path, params: {
+          user: {
+            current_password: "password123",
+            password: "newpassword456",
+            password_confirmation: "different789"
+          }
+        }
+        expect(user.reload.valid_password?("password123")).to be true
+      end
+
+      it "新しいパスワードが短すぎる場合は変更されない" do
+        patch account_password_path, params: {
+          user: {
+            current_password: "password123",
+            password: "short",
+            password_confirmation: "short"
+          }
+        }
+        expect(user.reload.valid_password?("password123")).to be true
+      end
+    end
+
+    context "Google連携ユーザーでログイン中" do
+      let(:user) { create(:user, :google_user) }
+
+      before { sign_in user }
+
+      it "パスワード変更はできずアカウント設定ページにリダイレクトされる" do
+        patch account_password_path, params: {
+          user: {
+            current_password: "anything",
+            password: "newpassword456",
+            password_confirmation: "newpassword456"
+          }
+        }
+        expect(response).to redirect_to(account_path)
+      end
+    end
+  end
+end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Accounts", type: :request do
+  describe "GET /account" do
+    context "未ログインの場合" do
+      it "ログインページにリダイレクトされる" do
+        get account_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "通常ユーザーでログイン中" do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it "正常に表示される" do
+        get account_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "パスワード変更フォームが表示される" do
+        get account_path
+        expect(response.body).to include("パスワード変更")
+        expect(response.body).to include("現在のパスワード")
+      end
+
+      it "退会ボタンが表示される" do
+        get account_path
+        expect(response.body).to include("退会する")
+      end
+    end
+
+    context "Google連携ユーザーでログイン中" do
+      let(:user) { create(:user, :google_user) }
+
+      before { sign_in user }
+
+      it "正常に表示される" do
+        get account_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "パスワード変更フォームが表示されない" do
+        get account_path
+        expect(response.body).not_to include("現在のパスワード")
+      end
+
+      it "退会ボタンが表示される" do
+        get account_path
+        expect(response.body).to include("退会する")
+      end
+    end
+  end
+end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -46,4 +46,63 @@ RSpec.describe "Users::Registrations", type: :request do
       expect(user.reload.name).to eq("変更前")
     end
   end
+
+  describe "DELETE /users (退会 - 通常ユーザー)" do
+    it "現在のパスワードが正しければ退会できる" do
+      expect {
+        delete user_registration_path, params: { user: { current_password: "password123" } }
+      }.to change(User, :count).by(-1)
+    end
+
+    it "退会成功後はトップページにリダイレクトされる" do
+      delete user_registration_path, params: { user: { current_password: "password123" } }
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "関連データも一緒に削除される" do
+      create(:favorite, user: user)
+      expect {
+        delete user_registration_path, params: { user: { current_password: "password123" } }
+      }.to change(Favorite, :count).by(-1)
+    end
+
+    it "現在のパスワードが間違っていれば退会できない" do
+      expect {
+        delete user_registration_path, params: { user: { current_password: "wrongpassword" } }
+      }.not_to change(User, :count)
+    end
+
+    it "現在のパスワードが間違っていればアカウント設定ページにリダイレクトされる" do
+      delete user_registration_path, params: { user: { current_password: "wrongpassword" } }
+      expect(response).to redirect_to(account_path)
+    end
+
+    it "現在のパスワードが空なら退会できない" do
+      expect {
+        delete user_registration_path, params: { user: { current_password: "" } }
+      }.not_to change(User, :count)
+    end
+  end
+
+  describe "DELETE /users (退会 - Google連携ユーザー)" do
+    let(:user) { create(:user, :google_user) }
+
+    it "確認テキストが『退会』なら退会できる" do
+      expect {
+        delete user_registration_path, params: { user: { deletion_confirmation: "退会" } }
+      }.to change(User, :count).by(-1)
+    end
+
+    it "確認テキストが一致しなければ退会できない" do
+      expect {
+        delete user_registration_path, params: { user: { deletion_confirmation: "違う" } }
+      }.not_to change(User, :count)
+    end
+
+    it "確認テキストが空なら退会できない" do
+      expect {
+        delete user_registration_path, params: { user: {} }
+      }.not_to change(User, :count)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `/account` にアカウント設定ページを新設（プロフィール編集リンク・パスワード変更・退会）
- パスワード変更を `Account::PasswordsController` に分離し、`Users::RegistrationsController` の責務を整理
- 退会時のセキュリティ強化：通常ユーザーはパスワード再入力、Google連携ユーザーは確認テキスト「退会」入力を必須化
- `User#password_changeable?` でOAuth判定ロジックをモデルに集約（Viewからビジネスロジックを排除）

## 変更ファイル
### 新規
- `app/controllers/accounts_controller.rb` — 設定ページ表示
- `app/controllers/account/passwords_controller.rb` — パスワード変更専用
- `app/views/accounts/show.html.erb` — 設定ページUI

### 変更
- `app/models/user.rb` — `password_changeable?` 追加
- `app/controllers/users/registrations_controller.rb` — `destroy` オーバーライド、`update_resource` をシンプルに戻す
- `app/views/profiles/show.html.erb` — アカウント設定リンク追加
- `config/routes.rb` — `/account`, `/account/password` 追加

## Test plan
- [x] RSpec 284 examples, 0 failures
- [x] rubocop: no offenses
- [x] brakeman: no warnings
- [ ] 通常ユーザーで `/account` にアクセスし、パスワード変更フォームが表示されること
- [ ] 正しいパスワードでパスワード変更が成功すること
- [ ] 間違ったパスワードでエラーが表示されること
- [ ] 通常ユーザーの退会時にパスワード入力が必要なこと
- [ ] Google連携ユーザーでパスワード変更フォームが非表示であること
- [ ] Google連携ユーザーの退会時に「退会」テキスト入力が必要なこと
- [ ] 退会の確認ダイアログが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)