### PR TITLE
fix: エラー時にフォーム入力欄の幅が崩れる問題を修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module Myapp
     config.i18n.default_locale = :ja
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.action_view.field_error_proc = proc { |html_tag, _instance| html_tag }
   end
 end


### PR DESCRIPTION
## Summary
- Railsデフォルトの`field_error_proc`がバリデーションエラー時にinput/labelを`<div class="field_with_errors">`で囲むため、Tailwindのflexレイアウトが崩れて入力欄の幅が縮小していた
- `config.action_view.field_error_proc`をタグそのままを返すよう変更し、ラッパーdivを無効化
- エラー表示はView側で`errors.full_messages`を使って一括表示済みのため、ラッパーは不要

## Test plan
- [x] RSpec 284 examples, 0 failures
- [x] rubocop: no offenses
- [ ] パスワード変更で不正な入力をした際、入力欄の幅が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)