### PR TITLE
feat: 管理画面の出来事記事ページ(一覧・作成・編集・削除)を実装

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,6 +1,7 @@
 class Admin::EventsController < Admin::BaseController
-  before_action :set_event, only: %i[destroy]
+  before_action :set_event, only: %i[edit update destroy]
   before_action :set_filter_options, only: %i[index]
+  before_action :set_form_options, only: %i[new create edit update]
 
   def index
     @events = Event.includes(:period, :category, :region, :study_unit)
@@ -9,6 +10,29 @@ class Admin::EventsController < Admin::BaseController
                    .by_category(params[:category_id])
                    .order(updated_at: :desc)
                    .page(params[:page]).per(20)
+  end
+
+  def new
+    @event = Event.new
+  end
+
+  def create
+    @event = Event.new(event_params)
+    if @event.save
+      redirect_to admin_events_path, notice: "「#{@event.title}」を作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @event.update(event_params)
+      redirect_to admin_events_path, notice: "「#{@event.title}」を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy
@@ -26,5 +50,26 @@ class Admin::EventsController < Admin::BaseController
     @periods = Period.all
     @regions = Region.all
     @categories = Category.all
+  end
+
+  def set_form_options
+    @periods = Period.all
+    @regions = Region.all
+    @categories = Category.all
+    @study_units = StudyUnit.all
+    @characters = Character.order(:name)
+  end
+
+  def event_params
+    permitted = params.require(:event).permit(
+      :title, :year, :description,
+      :period_id, :category_id, :region_id, :study_unit_id,
+      :image, :image_credit,
+      character_ids: []
+    )
+    if permitted.key?(:character_ids)
+      permitted[:character_ids] = Character.where(id: permitted[:character_ids]).ids
+    end
+    permitted
   end
 end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,0 +1,30 @@
+class Admin::EventsController < Admin::BaseController
+  before_action :set_event, only: %i[destroy]
+  before_action :set_filter_options, only: %i[index]
+
+  def index
+    @events = Event.includes(:period, :category, :region, :study_unit)
+                   .by_period(params[:period_id])
+                   .by_region(params[:region_id])
+                   .by_category(params[:category_id])
+                   .order(updated_at: :desc)
+                   .page(params[:page]).per(20)
+  end
+
+  def destroy
+    @event.destroy!
+    redirect_to admin_events_path, notice: "「#{@event.title}」を削除しました"
+  end
+
+  private
+
+  def set_event
+    @event = Event.find(params[:id])
+  end
+
+  def set_filter_options
+    @periods = Period.all
+    @regions = Region.all
+    @categories = Category.all
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -3,6 +3,7 @@ module AdminHelper
     [
       { label: "ダッシュボード", path: admin_root_path, icon: "admin/shared/icons/dashboard" },
       { label: "人物記事", path: admin_characters_path, icon: "admin/shared/icons/content" },
+      { label: "出来事記事", path: admin_events_path, icon: "admin/shared/icons/events" },
       { label: "クイズ管理", path: admin_root_path, icon: "admin/shared/icons/quiz" },
       { label: "ユーザー管理", path: admin_root_path, icon: "admin/shared/icons/users" }
     ]

--- a/app/javascript/controllers/character_picker_controller.js
+++ b/app/javascript/controllers/character_picker_controller.js
@@ -1,0 +1,161 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 関連人物のタグ入力UI
+// - 検索でフィルタ、候補クリックで追加
+// - 選択済みはpillで表示、×で削除
+// - hidden input (event[character_ids][]) で選択状態をサーバに送信
+export default class extends Controller {
+  static targets = ["input", "suggestions", "selected", "hiddenFields", "name"]
+  static values = {
+    characters: Array,
+    paramName: { type: String, default: "event[character_ids][]" }
+  }
+
+  connect() {
+    this.selectedIds = Array.from(
+      this.element.querySelectorAll("[data-initial-selected]")
+    ).map((el) => Number(el.dataset.initialSelected))
+    this.render()
+
+    this.handleOutsideClick = this.handleOutsideClick.bind(this)
+    this.handleKeydown = this.handleKeydown.bind(this)
+    document.addEventListener("click", this.handleOutsideClick)
+    document.addEventListener("keydown", this.handleKeydown)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.handleOutsideClick)
+    document.removeEventListener("keydown", this.handleKeydown)
+  }
+
+  handleOutsideClick(event) {
+    if (!this.element.contains(event.target)) {
+      this.hideSuggestions()
+    }
+  }
+
+  handleKeydown(event) {
+    if (event.key === "Escape" && !this.suggestionsTarget.classList.contains("hidden")) {
+      this.hideSuggestions()
+    }
+  }
+
+  // 検索中にEnterキーでフォーム送信されないように抑止する
+  preventSubmit(event) {
+    if (event.key === "Enter") {
+      event.preventDefault()
+    }
+  }
+
+  search(event) {
+    const query = event.target.value.trim()
+    if (!query) {
+      this.hideSuggestions()
+      return
+    }
+    const lowered = query.toLowerCase()
+    const filtered = this.charactersValue.filter(
+      (c) =>
+        c.name.toLowerCase().includes(lowered) &&
+        !this.selectedIds.includes(c.id)
+    )
+    this.renderSuggestions(filtered.slice(0, 10))
+  }
+
+  add(event) {
+    const id = Number(event.currentTarget.dataset.id)
+    if (this.selectedIds.includes(id)) return
+    this.selectedIds = [...this.selectedIds, id]
+    this.inputTarget.value = ""
+    this.hideSuggestions()
+    this.render()
+  }
+
+  remove(event) {
+    const id = Number(event.currentTarget.dataset.id)
+    this.selectedIds = this.selectedIds.filter((x) => x !== id)
+    this.render()
+  }
+
+  hideSuggestions() {
+    this.suggestionsTarget.classList.add("hidden")
+    this.suggestionsTarget.replaceChildren()
+  }
+
+  render() {
+    this.renderSelected()
+    this.renderHiddenFields()
+  }
+
+  renderSelected() {
+    this.selectedTarget.replaceChildren(
+      ...this.selectedIds
+        .map((id) => this.findCharacter(id))
+        .filter(Boolean)
+        .map((c) => this.buildPill(c))
+    )
+  }
+
+  renderHiddenFields() {
+    // 空文字を1つ含めることで、全解除されてもcharacter_idsキーが送信される
+    const base = document.createElement("input")
+    base.type = "hidden"
+    base.name = this.paramNameValue
+    base.value = ""
+
+    const inputs = this.selectedIds.map((id) => {
+      const el = document.createElement("input")
+      el.type = "hidden"
+      el.name = this.paramNameValue
+      el.value = String(id)
+      return el
+    })
+
+    this.hiddenFieldsTarget.replaceChildren(base, ...inputs)
+  }
+
+  renderSuggestions(items) {
+    if (items.length === 0) {
+      this.hideSuggestions()
+      return
+    }
+    const buttons = items.map((c) => {
+      const btn = document.createElement("button")
+      btn.type = "button"
+      btn.dataset.id = c.id
+      btn.dataset.action = "click->character-picker#add"
+      btn.className =
+        "block w-full text-left px-3 py-2 text-sm text-[#191c1e] hover:bg-[#f2f4f6]"
+      btn.textContent = c.name
+      return btn
+    })
+    this.suggestionsTarget.replaceChildren(...buttons)
+    this.suggestionsTarget.classList.remove("hidden")
+  }
+
+  buildPill(character) {
+    const pill = document.createElement("span")
+    pill.className =
+      "bg-[#2170e4] inline-flex gap-1.5 items-center pl-3 pr-2 py-1.5 rounded-full text-white text-xs font-medium"
+
+    const label = document.createElement("span")
+    label.textContent = character.name
+    pill.appendChild(label)
+
+    const close = document.createElement("button")
+    close.type = "button"
+    close.dataset.id = character.id
+    close.dataset.action = "click->character-picker#remove"
+    close.className =
+      "size-4 inline-flex items-center justify-center rounded-full hover:bg-white/20"
+    close.setAttribute("aria-label", `${character.name}を外す`)
+    close.textContent = "×"
+    pill.appendChild(close)
+
+    return pill
+  }
+
+  findCharacter(id) {
+    return this.charactersValue.find((c) => c.id === id)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -27,3 +27,6 @@ application.register("quiz-runner", QuizRunnerController)
 
 import ImagePreviewController from "./image_preview_controller"
 application.register("image-preview", ImagePreviewController)
+
+import CharacterPickerController from "./character_picker_controller"
+application.register("character-picker", CharacterPickerController)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,6 +17,10 @@ class Event < ApplicationRecord
   validates :year, presence: true
   validates :description, presence: true
 
+  scope :by_period, ->(id) { where(period_id: id) if id.present? }
+  scope :by_region, ->(id) { where(region_id: id) if id.present? }
+  scope :by_category, ->(id) { where(category_id: id) if id.present? }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[title description]
   end

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -1,0 +1,167 @@
+<%= form_with(model: [:admin, event], class: "grid grid-cols-3 gap-8 pt-2 pb-28") do |f| %>
+  <%# 左カラム: メインフォーム (2/3) %>
+  <div class="col-span-2 space-y-8">
+    <%# 基本情報カード %>
+    <div class="bg-white rounded-xl shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] p-8">
+      <div class="border-l-4 border-[#0058be] pl-5 mb-6">
+        <h3 class="text-lg font-bold text-[#191c1e] leading-7">基本情報</h3>
+      </div>
+
+      <div class="grid grid-cols-2 gap-6">
+        <%# タイトル %>
+        <div class="col-span-2">
+          <%= f.label :title, "タイトル *", class: "block text-xs font-bold text-[#424754] mb-2" %>
+          <%= f.text_field :title, placeholder: "例: 源氏物語の成立", class: "bg-[#f7f9fb] w-full rounded-lg px-4 py-3 text-base text-[#191c1e] placeholder-[#6b7280] focus:outline-none focus:ring-2 focus:ring-[#2563eb]" %>
+          <% if event.errors[:title].any? %>
+            <p class="text-red-500 text-xs mt-1"><%= event.errors[:title].first %></p>
+          <% end %>
+        </div>
+
+        <%# 発生年 %>
+        <div>
+          <%= f.label :year, "発生年 (西暦) *", class: "block text-xs font-bold text-[#424754] mb-2" %>
+          <%= f.number_field :year, placeholder: "例: 1008", class: "bg-[#f7f9fb] w-full rounded-lg px-4 py-3 text-base text-[#191c1e] placeholder-[#6b7280] focus:outline-none focus:ring-2 focus:ring-[#2563eb]" %>
+          <% if event.errors[:year].any? %>
+            <p class="text-red-500 text-xs mt-1"><%= event.errors[:year].first %></p>
+          <% end %>
+        </div>
+
+        <%# 時代区分 %>
+        <div>
+          <%= f.label :period_id, "時代区分 *", class: "block text-xs font-bold text-[#424754] mb-2" %>
+          <%= f.collection_select :period_id, @periods, :id, :name, { include_blank: "選択してください" }, class: "bg-[#f7f9fb] w-full rounded-lg px-4 py-3 text-base text-[#191c1e] appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-[#2563eb]" %>
+          <% if event.errors[:period].any? %>
+            <p class="text-red-500 text-xs mt-1"><%= event.errors[:period].first %></p>
+          <% end %>
+        </div>
+
+        <%# 地域 %>
+        <div>
+          <%= f.label :region_id, "地域 *", class: "block text-xs font-bold text-[#424754] mb-2" %>
+          <%= f.collection_select :region_id, @regions, :id, :name, { include_blank: "選択してください" }, class: "bg-[#f7f9fb] w-full rounded-lg px-4 py-3 text-base text-[#191c1e] appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-[#2563eb]" %>
+          <% if event.errors[:region].any? %>
+            <p class="text-red-500 text-xs mt-1"><%= event.errors[:region].first %></p>
+          <% end %>
+        </div>
+
+        <%# カテゴリー %>
+        <div>
+          <%= f.label :category_id, "カテゴリー *", class: "block text-xs font-bold text-[#424754] mb-2" %>
+          <%= f.collection_select :category_id, @categories, :id, :name, { include_blank: "選択してください" }, class: "bg-[#f7f9fb] w-full rounded-lg px-4 py-3 text-base text-[#191c1e] appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-[#2563eb]" %>
+          <% if event.errors[:category].any? %>
+            <p class="text-red-500 text-xs mt-1"><%= event.errors[:category].first %></p>
+          <% end %>
+        </div>
+
+        <%# 学習単位 %>
+        <div class="col-span-2">
+          <%= f.label :study_unit_id, "学習単位 *", class: "block text-xs font-bold text-[#424754] mb-2" %>
+          <%= f.collection_select :study_unit_id, @study_units, :id, :name, { include_blank: "選択してください" }, class: "bg-[#f7f9fb] w-full rounded-lg px-4 py-3 text-base text-[#191c1e] appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-[#2563eb]" %>
+          <% if event.errors[:study_unit].any? %>
+            <p class="text-red-500 text-xs mt-1"><%= event.errors[:study_unit].first %></p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <%# 関連人物カード %>
+    <div class="bg-white rounded-xl shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] p-8">
+      <div class="border-l-4 border-[#0058be] pl-5 mb-6">
+        <h3 class="text-lg font-bold text-[#191c1e] leading-7">関連人物</h3>
+      </div>
+
+      <% if @characters.any? %>
+        <div class="relative"
+             data-controller="character-picker"
+             data-character-picker-characters-value="<%= @characters.map { |c| { id: c.id, name: c.name } }.to_json %>">
+          <%# 初期選択を data 属性で渡す %>
+          <% event.character_ids.each do |id| %>
+            <span class="hidden" data-initial-selected="<%= id %>"></span>
+          <% end %>
+
+          <div class="bg-[#f7f9fb] rounded-lg p-3 flex flex-wrap gap-2 items-center min-h-[56px]">
+            <div data-character-picker-target="selected" class="contents"></div>
+            <input type="text"
+                   placeholder="人物を追加..."
+                   autocomplete="off"
+                   data-character-picker-target="input"
+                   data-action="input->character-picker#search keydown->character-picker#preventSubmit"
+                   class="flex-1 min-w-[140px] bg-transparent text-sm text-[#191c1e] placeholder-[#6b7280] focus:outline-none px-2 py-1">
+          </div>
+
+          <div data-character-picker-target="suggestions"
+               class="hidden absolute z-20 left-0 right-0 mt-1 bg-white rounded-lg border border-[#c2c6d6] shadow-lg max-h-60 overflow-y-auto"></div>
+
+          <div data-character-picker-target="hiddenFields"></div>
+        </div>
+        <p class="text-xs text-[#586377] mt-2">名前で検索して候補から追加、× で削除できます</p>
+      <% else %>
+        <p class="text-sm text-[#586377]">登録済みの人物がいません。</p>
+      <% end %>
+    </div>
+
+    <%# 本文カード %>
+    <div class="bg-white rounded-xl shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] p-8">
+      <div class="border-l-4 border-[#0058be] pl-5 mb-6">
+        <h3 class="text-lg font-bold text-[#191c1e] leading-7">本文 *</h3>
+      </div>
+      <%= f.text_area :description, placeholder: "詳細な解説を記述してください...", rows: 12, class: "bg-[#f7f9fb] w-full rounded-lg px-6 py-6 text-base text-[#191c1e] placeholder-[#6b7280] focus:outline-none focus:ring-2 focus:ring-[#2563eb] resize-y leading-7" %>
+      <% if event.errors[:description].any? %>
+        <p class="text-red-500 text-xs mt-1"><%= event.errors[:description].first %></p>
+      <% end %>
+    </div>
+  </div>
+
+  <%# 右カラム: サイドバー (1/3) %>
+  <div class="col-span-1 space-y-8">
+    <%# 画像カード %>
+    <div class="bg-white rounded-xl shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] p-8">
+      <div class="border-l-4 border-[#0058be] pl-5 mb-6">
+        <h3 class="text-lg font-bold text-[#191c1e] leading-7">画像</h3>
+      </div>
+
+      <div data-controller="image-preview">
+        <%# 既存画像またはプレビュー %>
+        <div class="mb-4 rounded-xl overflow-hidden">
+          <% if event.image.attached? %>
+            <img data-image-preview-target="preview" src="<%= url_for(event.image) %>" class="w-full h-auto object-cover">
+          <% elsif event.image_url.present? %>
+            <img data-image-preview-target="preview" src="<%= event.image_url %>" class="w-full h-auto object-cover">
+          <% else %>
+            <img data-image-preview-target="preview" src="" class="w-full h-auto object-cover hidden">
+          <% end %>
+        </div>
+
+        <%= f.file_field :image, id: "event_image_input", class: "hidden", accept: "image/png,image/jpeg,image/webp", data: { image_preview_target: "input", action: "change->image-preview#select" } %>
+
+        <label for="event_image_input" data-image-preview-target="placeholder dropzone" data-action="dragover->image-preview#dragover dragleave->image-preview#dragleave drop->image-preview#drop" class="block bg-[#f7f9fb] border-2 border-dashed border-[#c2c6d6] rounded-xl p-8 text-center cursor-pointer hover:border-[#2563eb] transition-colors <%= 'hidden' if event.image.attached? || event.image_url.present? %>">
+          <svg class="size-8 text-[#94a3b8] mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"/>
+          </svg>
+          <p class="text-sm font-bold text-[#191c1e]">クリックまたはドラッグ&ドロップ</p>
+          <p class="text-xs text-[#424754] mt-1">JPG, PNG, WebP (最大 5MB)</p>
+        </label>
+
+        <label for="event_image_input" class="block mt-3 bg-[#f7f9fb] text-[#424754] text-xs font-bold text-center px-4 py-2 rounded-lg cursor-pointer hover:bg-[#e6e8ea]">
+          画像を変更する
+        </label>
+        <p data-image-preview-target="filename" class="hidden text-xs text-[#0058be] font-medium mt-2 text-center truncate"></p>
+      </div>
+
+      <% if event.errors[:image].any? %>
+        <p class="text-red-500 text-xs mt-2"><%= event.errors[:image].first %></p>
+      <% end %>
+
+      <div class="mt-4">
+        <%= f.label :image_credit, "画像クレジット", class: "block text-xs font-bold text-[#424754] mb-2" %>
+        <%= f.text_field :image_credit, placeholder: "例: Photo by ...", class: "bg-[#f7f9fb] w-full rounded-lg px-4 py-3 text-sm text-[#191c1e] placeholder-[#6b7280] focus:outline-none focus:ring-2 focus:ring-[#2563eb]" %>
+      </div>
+    </div>
+  </div>
+
+  <%# 下部固定バー %>
+  <div class="col-span-3 fixed bottom-0 left-[256px] right-0 h-20 bg-[rgba(255,255,255,0.8)] backdrop-blur-xl border-t border-[rgba(194,198,214,0.1)] flex items-center justify-between px-8 z-30">
+    <%= link_to "キャンセル", admin_events_path, class: "text-sm font-bold text-[#424754] px-6 py-3 hover:text-[#191c1e]" %>
+    <%= f.submit event.persisted? ? "更新する" : "作成する", class: "bg-gradient-to-br from-[#0058be] to-[#2170e4] text-white text-sm font-bold px-10 py-3 rounded-lg shadow-[0px_10px_15px_-3px_rgba(0,88,190,0.2)] cursor-pointer hover:opacity-90" %>
+  </div>
+<% end %>

--- a/app/views/admin/events/edit.html.erb
+++ b/app/views/admin/events/edit.html.erb
@@ -1,0 +1,16 @@
+<%# パンくずリスト %>
+<div class="flex items-center gap-2 mb-4">
+  <%= link_to "ホーム", admin_root_path, class: "text-sm font-medium text-[#424754] hover:text-[#191c1e]" %>
+  <span class="text-sm text-[#c2c6d6]">/</span>
+  <%= link_to "出来事", admin_events_path, class: "text-sm font-medium text-[#424754] hover:text-[#191c1e]" %>
+  <span class="text-sm text-[#c2c6d6]">/</span>
+  <span class="text-sm font-medium text-[#191c1e]"><%= @event.title %> を編集</span>
+</div>
+
+<%# ヘッダー %>
+<div class="mb-2">
+  <h1 class="text-3xl font-bold text-[#191c1e] tracking-[-0.75px]"><%= @event.title %> を編集</h1>
+  <p class="text-base text-[#424754] mt-2">出来事の情報を編集します。必須項目（*）を入力してください。</p>
+</div>
+
+<%= render "form", event: @event %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -11,13 +11,21 @@
 
 <%# ヘッダー %>
 <div class="flex items-end justify-between mb-8">
-  <div>
-    <h1 class="text-4xl font-bold text-[#191c1e] tracking-[-0.9px]">出来事一覧</h1>
-    <p class="text-base text-[#424754] mt-1">日本文化史を彩る重要な歴史的事象の管理</p>
+  <div class="flex items-end gap-4">
+    <div>
+      <h1 class="text-4xl font-bold text-[#191c1e] tracking-[-0.9px]">出来事一覧</h1>
+      <p class="text-base text-[#424754] mt-1">日本文化史を彩る重要な歴史的事象の管理</p>
+    </div>
+    <span class="bg-[#d8e2ff] text-[#001a42] text-xs font-bold px-3 py-1 rounded-full mb-2">
+      全 <%= @events.total_count %> 件
+    </span>
   </div>
-  <span class="bg-[#d8e2ff] text-[#001a42] text-xs font-bold px-3 py-1 rounded-full">
-    全 <%= @events.total_count %> 件
-  </span>
+  <%= link_to new_admin_event_path, class: "flex gap-2 items-center bg-[#2563eb] text-white text-sm font-bold px-6 py-3 rounded-lg shadow-[0px_10px_15px_-3px_rgba(37,99,235,0.2)] hover:opacity-90" do %>
+    <svg class="size-3.5" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/>
+    </svg>
+    新規追加
+  <% end %>
 </div>
 
 <%# フィルター %>
@@ -67,7 +75,7 @@
       <col class="w-[128px]" />
       <col class="w-[112px]" />
       <col class="w-[128px]" />
-      <col class="w-[96px]" />
+      <col class="w-[128px]" />
     </colgroup>
     <thead>
       <tr class="bg-[rgba(242,244,246,0.5)]">
@@ -113,6 +121,11 @@
           </td>
           <td class="px-6 py-4">
             <div class="flex gap-2 justify-end">
+              <%= link_to edit_admin_event_path(event), class: "bg-[#f2f4f6] p-2 rounded-lg hover:bg-[#e2e4e6]" do %>
+                <svg class="size-3.5 text-[#424754]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10"/>
+                </svg>
+              <% end %>
               <%= button_to admin_event_path(event), method: :delete, form: { data: { turbo_confirm: "「#{event.title}」を削除しますか？" } }, class: "bg-[#f2f4f6] p-2 rounded-lg hover:bg-red-100" do %>
                 <svg class="size-3.5 text-[#424754] hover:text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,0 +1,138 @@
+<%# パンくずリスト %>
+<div class="flex items-center gap-2 mb-4">
+  <span class="text-[11px] font-bold text-[rgba(66,71,84,0.6)] uppercase tracking-[1.1px]">
+    <%= link_to "ホーム", admin_root_path, class: "hover:text-[#424754]" %>
+  </span>
+  <span class="text-[11px] text-[#c2c6d6]">/</span>
+  <span class="text-[11px] font-bold text-[rgba(66,71,84,0.6)] uppercase tracking-[1.1px]">コンテンツ</span>
+  <span class="text-[11px] text-[#c2c6d6]">/</span>
+  <span class="text-[11px] font-bold text-[#424754] uppercase tracking-[1.1px]">出来事</span>
+</div>
+
+<%# ヘッダー %>
+<div class="flex items-end justify-between mb-8">
+  <div>
+    <h1 class="text-4xl font-bold text-[#191c1e] tracking-[-0.9px]">出来事一覧</h1>
+    <p class="text-base text-[#424754] mt-1">日本文化史を彩る重要な歴史的事象の管理</p>
+  </div>
+  <span class="bg-[#d8e2ff] text-[#001a42] text-xs font-bold px-3 py-1 rounded-full">
+    全 <%= @events.total_count %> 件
+  </span>
+</div>
+
+<%# フィルター %>
+<div class="bg-white rounded-xl shadow-[0px_12px_32px_0px_rgba(25,28,30,0.04)] p-6 flex gap-4 items-center mb-8">
+  <%= form_tag admin_events_path, method: :get, class: "flex gap-4 items-center w-full" do %>
+    <div class="relative flex-1 min-w-[160px]">
+      <%= select_tag :period_id,
+        options_from_collection_for_select(@periods, :id, :name, params[:period_id]),
+        include_blank: "時代で絞り込み",
+        class: "bg-[#f2f4f6] w-full rounded-lg pl-4 pr-10 py-2.5 text-sm font-medium text-[#424754] appearance-none cursor-pointer",
+        onchange: "this.form.requestSubmit()" %>
+      <svg class="absolute right-3 top-1/2 -translate-y-1/2 size-3 text-[#424754] pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+      </svg>
+    </div>
+    <div class="relative flex-1 min-w-[160px]">
+      <%= select_tag :region_id,
+        options_from_collection_for_select(@regions, :id, :name, params[:region_id]),
+        include_blank: "地域で絞り込み",
+        class: "bg-[#f2f4f6] w-full rounded-lg pl-4 pr-10 py-2.5 text-sm font-medium text-[#424754] appearance-none cursor-pointer",
+        onchange: "this.form.requestSubmit()" %>
+      <svg class="absolute right-3 top-1/2 -translate-y-1/2 size-3 text-[#424754] pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+      </svg>
+    </div>
+    <div class="relative flex-1 min-w-[160px]">
+      <%= select_tag :category_id,
+        options_from_collection_for_select(@categories, :id, :name, params[:category_id]),
+        include_blank: "カテゴリで絞り込み",
+        class: "bg-[#f2f4f6] w-full rounded-lg pl-4 pr-10 py-2.5 text-sm font-medium text-[#424754] appearance-none cursor-pointer",
+        onchange: "this.form.requestSubmit()" %>
+      <svg class="absolute right-3 top-1/2 -translate-y-1/2 size-3 text-[#424754] pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+      </svg>
+    </div>
+    <%= link_to "リセット", admin_events_path, class: "bg-[#e6e8ea] text-[#586377] text-sm font-bold px-6 py-2.5 rounded-lg hover:opacity-80" %>
+  <% end %>
+</div>
+
+<%# テーブル %>
+<div class="bg-white rounded-xl shadow-[0px_12px_32px_0px_rgba(25,28,30,0.04)] overflow-clip">
+  <table class="w-full table-fixed">
+    <colgroup>
+      <col class="w-[112px]" />
+      <col />
+      <col class="w-[96px]" />
+      <col class="w-[128px]" />
+      <col class="w-[112px]" />
+      <col class="w-[128px]" />
+      <col class="w-[96px]" />
+    </colgroup>
+    <thead>
+      <tr class="bg-[rgba(242,244,246,0.5)]">
+        <th class="text-left text-[11px] font-bold text-[rgba(66,71,84,0.7)] uppercase tracking-[1.1px] px-6 py-4">画像</th>
+        <th class="text-left text-[11px] font-bold text-[rgba(66,71,84,0.7)] uppercase tracking-[1.1px] px-6 py-4">タイトル</th>
+        <th class="text-left text-[11px] font-bold text-[rgba(66,71,84,0.7)] uppercase tracking-[1.1px] px-6 py-4">発生年</th>
+        <th class="text-left text-[11px] font-bold text-[rgba(66,71,84,0.7)] uppercase tracking-[1.1px] px-6 py-4">時代</th>
+        <th class="text-left text-[11px] font-bold text-[rgba(66,71,84,0.7)] uppercase tracking-[1.1px] px-6 py-4">地域</th>
+        <th class="text-left text-[11px] font-bold text-[rgba(66,71,84,0.7)] uppercase tracking-[1.1px] px-6 py-4">更新日</th>
+        <th class="text-right text-[11px] font-bold text-[rgba(66,71,84,0.7)] uppercase tracking-[1.1px] px-6 py-4">操作</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @events.each_with_index do |event, i| %>
+        <tr class="border-t border-[#f2f4f6] <%= 'bg-[rgba(242,244,246,0.3)]' if i.odd? %> hover:bg-[rgba(242,244,246,0.5)]">
+          <td class="px-6 py-4">
+            <% if event.image.attached? %>
+              <%= image_tag event.image, class: "w-16 h-10 rounded object-cover shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] shrink-0" %>
+            <% elsif event.image_url.present? %>
+              <%= image_tag event.image_url, class: "w-16 h-10 rounded object-cover shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] shrink-0" %>
+            <% else %>
+              <div class="w-16 h-10 rounded bg-[#f2f4f6] flex items-center justify-center shrink-0">
+                <svg class="size-4 text-[#94a3b8]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z"/>
+                </svg>
+              </div>
+            <% end %>
+          </td>
+          <td class="px-6 py-4">
+            <span class="text-sm font-bold text-[#191c1e] block truncate"><%= event.title %></span>
+          </td>
+          <td class="px-6 py-4">
+            <span class="text-sm font-medium text-[#545f73]"><%= event.year %></span>
+          </td>
+          <td class="px-6 py-4">
+            <span class="bg-[#d8e3fb] text-[#111c2d] text-xs font-medium px-2 py-1 rounded"><%= event.period.name %></span>
+          </td>
+          <td class="px-6 py-4">
+            <span class="text-sm text-[#545f73]"><%= event.region&.name %></span>
+          </td>
+          <td class="px-6 py-4">
+            <span class="text-sm text-[#727785]"><%= event.updated_at.strftime("%Y/%m/%d") %></span>
+          </td>
+          <td class="px-6 py-4">
+            <div class="flex gap-2 justify-end">
+              <%= button_to admin_event_path(event), method: :delete, form: { data: { turbo_confirm: "「#{event.title}」を削除しますか？" } }, class: "bg-[#f2f4f6] p-2 rounded-lg hover:bg-red-100" do %>
+                <svg class="size-3.5 text-[#424754] hover:text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/>
+                </svg>
+              <% end %>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%# ページネーション %>
+  <div class="flex items-center justify-between px-8 py-6 bg-[rgba(242,244,246,0.2)]">
+    <p class="text-sm font-medium text-[#424754]">
+      全 <span class="font-bold text-[#191c1e]"><%= @events.total_count %></span> 件中
+      <span class="font-bold text-[#191c1e]"><%= @events.total_count.zero? ? 0 : @events.offset_value + 1 %>〜<%= [@events.offset_value + @events.limit_value, @events.total_count].min %></span> 件表示
+    </p>
+    <div class="flex gap-1 items-center">
+      <%= paginate @events, theme: "admin" %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/events/new.html.erb
+++ b/app/views/admin/events/new.html.erb
@@ -1,0 +1,16 @@
+<%# パンくずリスト %>
+<div class="flex items-center gap-2 mb-4">
+  <%= link_to "ホーム", admin_root_path, class: "text-sm font-medium text-[#424754] hover:text-[#191c1e]" %>
+  <span class="text-sm text-[#c2c6d6]">/</span>
+  <%= link_to "出来事", admin_events_path, class: "text-sm font-medium text-[#424754] hover:text-[#191c1e]" %>
+  <span class="text-sm text-[#c2c6d6]">/</span>
+  <span class="text-sm font-medium text-[#191c1e]">新規作成</span>
+</div>
+
+<%# ヘッダー %>
+<div class="mb-2">
+  <h1 class="text-3xl font-bold text-[#191c1e] tracking-[-0.75px]">出来事の登録</h1>
+  <p class="text-base text-[#424754] mt-2">歴史的な出来事や文化的な節目をデータベースに登録します。</p>
+</div>
+
+<%= render "form", event: @event %>

--- a/app/views/admin/shared/icons/_events.html.erb
+++ b/app/views/admin/shared/icons/_events.html.erb
@@ -1,0 +1,3 @@
+<svg class="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+</svg>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root "dashboard#index"
     resources :characters
-    resources :events, only: %i[index destroy]
+    resources :events
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root "dashboard#index"
     resources :characters
+    resources :events, only: %i[index destroy]
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
       provider { "google_oauth2" }
       sequence(:uid) { |n| "google-uid-#{n}" }
     end
+
+    trait :admin do
+      role { :admin }
+    end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -55,4 +55,57 @@ RSpec.describe Event, type: :model do
       expect(association.options[:through]).to eq :event_characters
     end
   end
+
+  describe 'スコープ' do
+    let!(:period_a) { create(:period, name: '飛鳥時代') }
+    let!(:period_b) { create(:period, name: '奈良時代') }
+    let!(:region_a) { create(:region, name: '近畿') }
+    let!(:region_b) { create(:region, name: '関東') }
+    let!(:category_a) { create(:category, name: '政治') }
+    let!(:category_b) { create(:category, name: '文化') }
+
+    let!(:event_a) { create(:event, period: period_a, region: region_a, category: category_a) }
+    let!(:event_b) { create(:event, period: period_b, region: region_b, category: category_b) }
+
+    describe '.by_period' do
+      it '指定したperiod_idのeventだけ返すこと' do
+        expect(Event.by_period(period_a.id)).to contain_exactly(event_a)
+      end
+
+      it 'period_idが空なら全件返すこと' do
+        expect(Event.by_period(nil)).to contain_exactly(event_a, event_b)
+        expect(Event.by_period('')).to contain_exactly(event_a, event_b)
+      end
+    end
+
+    describe '.by_region' do
+      it '指定したregion_idのeventだけ返すこと' do
+        expect(Event.by_region(region_a.id)).to contain_exactly(event_a)
+      end
+
+      it 'region_idが空なら全件返すこと' do
+        expect(Event.by_region(nil)).to contain_exactly(event_a, event_b)
+        expect(Event.by_region('')).to contain_exactly(event_a, event_b)
+      end
+    end
+
+    describe '.by_category' do
+      it '指定したcategory_idのeventだけ返すこと' do
+        expect(Event.by_category(category_a.id)).to contain_exactly(event_a)
+      end
+
+      it 'category_idが空なら全件返すこと' do
+        expect(Event.by_category(nil)).to contain_exactly(event_a, event_b)
+        expect(Event.by_category('')).to contain_exactly(event_a, event_b)
+      end
+    end
+
+    describe 'スコープのチェーン' do
+      it '複数条件で絞り込めること' do
+        event_c = create(:event, period: period_a, region: region_b, category: category_a)
+        expect(Event.by_period(period_a.id).by_region(region_a.id)).to contain_exactly(event_a)
+        expect(Event.by_period(period_a.id)).to contain_exactly(event_a, event_c)
+      end
+    end
+  end
 end

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -84,6 +84,127 @@ RSpec.describe "Admin::Events", type: :request do
       end
     end
 
+    describe "GET /admin/events/new" do
+      it "200を返すこと" do
+        get new_admin_event_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "POST /admin/events" do
+      let!(:study_unit) { create(:study_unit) }
+      let(:valid_params) do
+        {
+          title: "大化の改新",
+          year: 645,
+          description: "中大兄皇子と中臣鎌足による政治改革",
+          period_id: period.id,
+          region_id: region.id,
+          category_id: category.id,
+          study_unit_id: study_unit.id
+        }
+      end
+
+      context "正常系" do
+        it "Eventが作成されリダイレクトすること" do
+          expect {
+            post admin_events_path, params: { event: valid_params }
+          }.to change { Event.count }.by(1)
+          expect(response).to redirect_to(admin_events_path)
+          expect(flash[:notice]).to include("大化の改新")
+        end
+
+        it "選択した関連人物が紐付くこと" do
+          character1 = create(:character, name: "中大兄皇子", period: period, study_unit: study_unit)
+          character2 = create(:character, name: "中臣鎌足", period: period, study_unit: study_unit)
+          post admin_events_path, params: {
+            event: valid_params.merge(character_ids: [ character1.id, character2.id ])
+          }
+          expect(Event.last.characters).to contain_exactly(character1, character2)
+        end
+
+        it "存在しないcharacter_idが混入していても既存IDだけで紐付くこと" do
+          character = create(:character, period: period, study_unit: study_unit)
+          expect {
+            post admin_events_path, params: {
+              event: valid_params.merge(character_ids: [ character.id, 999_999 ])
+            }
+          }.to change { Event.count }.by(1)
+          expect(Event.last.characters).to contain_exactly(character)
+          expect(response).to redirect_to(admin_events_path)
+        end
+      end
+
+      context "異常系" do
+        it "titleが空ならEventは作成されず422を返すこと" do
+          expect {
+            post admin_events_path, params: { event: valid_params.merge(title: "") }
+          }.not_to change { Event.count }
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    describe "GET /admin/events/:id/edit" do
+      let!(:event) { create(:event) }
+
+      it "200を返すこと" do
+        get edit_admin_event_path(event)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "PATCH /admin/events/:id" do
+      let!(:event) { create(:event, title: "更新前") }
+      let!(:study_unit) { create(:study_unit) }
+
+      context "正常系" do
+        it "属性が更新されリダイレクトすること" do
+          patch admin_event_path(event), params: { event: { title: "更新後" } }
+          expect(event.reload.title).to eq("更新後")
+          expect(response).to redirect_to(admin_events_path)
+        end
+
+        it "関連人物を差し替えられること" do
+          old_char = create(:character, name: "旧人物", period: period, study_unit: study_unit)
+          new_char = create(:character, name: "新人物", period: period, study_unit: study_unit)
+          create(:event_character, event: event, character: old_char)
+
+          patch admin_event_path(event), params: {
+            event: { character_ids: [ new_char.id ] }
+          }
+          expect(event.reload.characters).to contain_exactly(new_char)
+        end
+
+        it "関連人物を全て外せること" do
+          character = create(:character, period: period, study_unit: study_unit)
+          create(:event_character, event: event, character: character)
+
+          patch admin_event_path(event), params: {
+            event: { character_ids: [ "" ] }
+          }
+          expect(event.reload.characters).to be_empty
+        end
+
+        it "存在しないcharacter_idが混入していても既存IDだけで差し替えられること" do
+          character = create(:character, period: period, study_unit: study_unit)
+          patch admin_event_path(event), params: {
+            event: { character_ids: [ character.id, 999_999 ] }
+          }
+          expect(event.reload.characters).to contain_exactly(character)
+          expect(response).to redirect_to(admin_events_path)
+        end
+      end
+
+      context "異常系" do
+        it "titleが空なら更新されず422を返すこと" do
+          patch admin_event_path(event), params: { event: { title: "" } }
+          expect(event.reload.title).to eq("更新前")
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
     describe "DELETE /admin/events/:id" do
       let!(:event) { create(:event) }
 

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Events", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:general_user) { create(:user) }
+
+  let!(:period) { create(:period, name: "飛鳥時代") }
+  let!(:region) { create(:region, name: "近畿") }
+  let!(:category) { create(:category, name: "政治") }
+
+  describe "認可" do
+    context "未ログインの場合" do
+      it "indexへのアクセスはログインページへリダイレクトされる" do
+        get admin_events_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "一般ユーザーでログインしている場合" do
+      before { sign_in general_user }
+
+      it "indexへのアクセスはroot_pathへリダイレクトされる" do
+        get admin_events_path
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("管理者権限が必要です")
+      end
+
+      it "destroyは実行できずリダイレクトされる" do
+        event = create(:event)
+        expect {
+          delete admin_event_path(event)
+        }.not_to change { Event.count }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "管理者でログインしている場合" do
+    before { sign_in admin }
+
+    describe "GET /admin/events" do
+      let!(:event_a) { create(:event, title: "飛鳥の出来事", period: period, region: region, category: category) }
+      let!(:event_b) do
+        create(:event,
+          title: "奈良の出来事",
+          period: create(:period, name: "奈良時代"),
+          region: create(:region, name: "関東"),
+          category: create(:category, name: "文化"))
+      end
+
+      it "200を返すこと" do
+        get admin_events_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "出来事のタイトルが表示されること" do
+        get admin_events_path
+        expect(response.body).to include("飛鳥の出来事")
+        expect(response.body).to include("奈良の出来事")
+      end
+
+      context "period_idで絞り込む場合" do
+        it "指定した時代のeventだけ表示されること" do
+          get admin_events_path, params: { period_id: period.id }
+          expect(response.body).to include("飛鳥の出来事")
+          expect(response.body).not_to include("奈良の出来事")
+        end
+      end
+
+      context "region_idで絞り込む場合" do
+        it "指定した地域のeventだけ表示されること" do
+          get admin_events_path, params: { region_id: region.id }
+          expect(response.body).to include("飛鳥の出来事")
+          expect(response.body).not_to include("奈良の出来事")
+        end
+      end
+
+      context "category_idで絞り込む場合" do
+        it "指定したカテゴリのeventだけ表示されること" do
+          get admin_events_path, params: { category_id: category.id }
+          expect(response.body).to include("飛鳥の出来事")
+          expect(response.body).not_to include("奈良の出来事")
+        end
+      end
+    end
+
+    describe "DELETE /admin/events/:id" do
+      let!(:event) { create(:event) }
+
+      it "Eventが削除されリダイレクトすること" do
+        expect {
+          delete admin_event_path(event)
+        }.to change { Event.count }.by(-1)
+        expect(response).to redirect_to(admin_events_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- 管理画面に出来事記事のCRUD機能を追加(`/admin/events`配下)
- 一覧はFigma準拠のフィルタ付きテーブル、作成・編集は3カラムフォーム
- 関連人物選択はStimulus製タグUIで検索・追加・削除可能

## 主な変更
- **Eventモデル**: `by_period` / `by_region` / `by_category` スコープを追加
- **Admin::EventsController**: 全CRUD実装、存在しない`character_id`を事前フィルタして500エラーを防止
- **ビュー**: `index` / `new` / `edit` / `_form` を追加、Figmaの青左ボーダーと3カラムレイアウトを再現
- **Stimulus**: `character_picker_controller.js` を新規作成。Enterでのフォーム誤送信防止、外クリック/ESCで候補クローズにも対応
- **ナビ**: サイドバーに「出来事記事」リンクを追加
- **RSpec**: Event model scope (7ケース) + Admin::Events request spec (20ケース) を追加

## Test plan
- [ ] **認可**: 未ログイン/一般ユーザー/管理者 でのアクセス制御
- [ ] **一覧**: 表示/フィルタ(時代・地域・カテゴリ)/リセット/ページネーション
- [ ] **新規追加**: 基本情報入力・関連人物タグUI・画像アップロード・送信
- [ ] **編集**: 既存データの初期表示/関連人物の差し替え/全削除/画像差し替え
- [ ] **削除**: 確認ダイアログ→削除
- [ ] **タグUIの挙動**: 検索・候補追加・×削除・Enter無効化・外クリック/ESCで閉じる
- [ ] **エラー系**: 必須項目未入力/5MB超画像/非画像ファイル
- [ ] RSpec 325 examples オールグリーン、rubocop/brakeman クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)