### PR TITLE
feat: 全ページのtitleタグを動的生成するpage_titleヘルパーを追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def page_title(title = nil)
+    title = content_for(:title) if title.nil?
+    site_name = I18n.t("site_name")
+    return site_name if title.blank?
+
+    "#{title} | #{site_name}"
+  end
 end

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "アカウント設定") %>
+
 <div class="max-w-[720px] mx-auto px-8 py-12">
   <div class="mb-8">
     <h1 class="text-[30px] font-medium text-[#0f172a]">アカウント設定</h1>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "記事一覧") %>
+
 <%# 検索バー %>
 <%= render "articles/search_bar" %>
 

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, @character.name) %>
+
 <%# Hero Section %>
 <section class="relative overflow-hidden bg-[#142283]">
   <% if @character.image.attached? %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "認証メール再送") %>
+
 <h2>Resend confirmation instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "パスワード変更") %>
+
 <div class="flex items-center justify-center py-12 px-4">
   <div class="max-w-md w-full bg-white rounded-lg shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">パスワード変更</h2>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "パスワード再設定") %>
+
 <div class="flex items-center justify-center py-12 px-4">
   <div class="max-w-md w-full bg-white rounded-lg shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">パスワード再設定</h2>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "アカウント編集") %>
+
 <div class="flex items-center justify-center py-12 px-4">
   <div class="max-w-md w-full bg-white rounded-lg shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">アカウント編集</h2>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "会員登録") %>
+
 <div class="flex items-center justify-center py-12 px-4">
   <div class="max-w-md w-full bg-white rounded-lg shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">会員登録</h2>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "ログイン") %>
+
 <div class="flex items-center justify-center py-12 px-4">
   <div class="max-w-md w-full bg-white rounded-lg shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">ログイン</h2>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "アカウントロック解除") %>
+
 <h2>Resend unlock instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, @event.title) %>
+
 <%# Hero Section %>
 <section class="relative overflow-hidden bg-[#142283]">
   <% if @event.image.attached? %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "お気に入り") %>
+
 <div class="max-w-[1280px] mx-auto px-8 py-12">
   <div class="mb-8">
     <h1 class="text-[30px] font-medium text-[#0f172a]">お気に入り</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Myapp" %></title>
+    <title><%= page_title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "マイページ") %>
+
 <div class="max-w-[1280px] mx-auto px-8 py-12">
   <%# ウェルカムメッセージ %>
   <div class="mb-8 flex items-start justify-between">

--- a/app/views/quiz_results/show.html.erb
+++ b/app/views/quiz_results/show.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "#{@quiz_result.quiz.title}の結果") %>
 <%
   message = quiz_result_message(@quiz_result.score)
   color = quiz_result_color(@quiz_result.score)

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "小テスト一覧") %>
+
 <div class="px-8 py-8 max-w-[1152px] mx-auto">
   <%# ページタイトル %>
   <div class="flex flex-col gap-2 mb-8">

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, @quiz.title) %>
+
 <div class="max-w-[768px] mx-auto px-4 py-8">
   <%= form_with url: quiz_results_path, method: :post, local: true,
         data: { controller: "quiz-runner", quiz_runner_total_value: @quiz.questions.size } do %>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "学習スケジュール編集") %>
+
 <div class="max-w-[960px] mx-auto px-8 pt-24 pb-20">
   <%# ヘッダーセクション %>
   <div class="mb-12">

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "学習スケジュール設定") %>
+
 <div class="max-w-[960px] mx-auto px-8 pt-24 pb-20">
   <%# ヘッダーセクション %>
   <div class="mb-12">

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "プライバシーポリシー | culture-link") %>
+<% provide(:title, "プライバシーポリシー") %>
 
 <div class="bg-[#f8fafc] w-full min-h-screen">
   <div class="max-w-4xl mx-auto px-6 py-20">

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "利用規約 | culture-link") %>
+<% provide(:title, "利用規約") %>
 
 <div class="bg-[#f8fafc] w-full min-h-screen">
   <div class="max-w-4xl mx-auto px-6 py-20">

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, @study_unit.name) %>
+
 <div class="flex h-[calc(100vh-64px)]">
   <%# サイドバー %>
   <aside class="w-64 border-r border-[#e5e7eb] bg-white flex flex-col justify-between px-6 py-6 flex-shrink-0">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,5 @@
 ja:
+  site_name: culture-link
   activerecord:
     attributes:
       schedule:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#page_title' do
+    let(:site_name) { I18n.t('site_name') }
+
+    context 'ページタイトルが指定されている場合' do
+      it '"ページ名 | サイト名" 形式で返す' do
+        expect(helper.page_title('ダッシュボード')).to eq("ダッシュボード | #{site_name}")
+      end
+    end
+
+    context 'ページタイトルが空文字の場合' do
+      it 'サイト名のみを返す' do
+        expect(helper.page_title('')).to eq(site_name)
+      end
+    end
+
+    context 'ページタイトルがnilの場合' do
+      it 'サイト名のみを返す' do
+        expect(helper.page_title(nil)).to eq(site_name)
+      end
+    end
+
+    context '引数なしで呼ばれた場合' do
+      it 'provide(:title)の値を使用する' do
+        helper.provide(:title, 'マイページ')
+        expect(helper.page_title).to eq("マイページ | #{site_name}")
+      end
+
+      it 'provide(:title)が未設定ならサイト名のみを返す' do
+        expect(helper.page_title).to eq(site_name)
+      end
+    end
+
+    context 'I18n.site_nameが "culture-link" の場合' do
+      it 'サイト名を I18n から参照する' do
+        expect(I18n.t('site_name')).to eq('culture-link')
+        expect(helper.page_title('テスト')).to eq('テスト | culture-link')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `ApplicationHelper#page_title` を追加し、`<title>` タグを「ページ名 | culture-link」形式で動的生成
- 各ビューで `provide(:title, "...")` を指定してページ固有タイトルを設定
- サイト名を I18n (`ja.site_name`) に定義して一元管理
- 静的/index/show/devise の全主要画面（21ビュー）に対応

## 変更内容
### 追加
- `app/helpers/application_helper.rb` — `page_title` ヘルパー実装
- `spec/helpers/application_helper_spec.rb` — 6件の単体テスト
- `config/locales/ja.yml` — `site_name: culture-link` を追加

### 変更
- `app/views/layouts/application.html.erb` — `<title><%= page_title %></title>` に変更
- 各ビュー（accounts/articles/characters/events/favorites/profiles/quiz_results/quizzes/schedules/static_pages/timelines/devise）— `provide(:title, "...")` 追加

## 設計判断
- **`content_for` ではなく `provide` を採用**: partial で誤って `content_for` を呼ぶとタイトルが連結されるバグ温床を回避
- **`@study_unit.name` を防御なしで使用**: コントローラで `find` 保証 + モデルで `presence: true` バリデーションがあるため
- **サイト名を I18n 化**: 将来の多言語化・ブランド名変更に備えて定数より柔軟

## Test plan
- [x] `bundle exec rspec` 全515件パス
- [x] `bundle exec rubocop` オフェンス0件
- [x] ブラウザ確認: 各カテゴリのタイトル表示・Turbo遷移時のタイトル更新
- [x] curl確認: トップ/プライバシー/利用規約/記事一覧/ログイン/会員登録 全て期待通り

🤖 Generated with [Claude Code](https://claude.com/claude-code)