### PR TITLE
fix: production起動時のZeitwerk eager_loadエラーを修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,9 @@ module Myapp
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    # omniauthはZeitwerk命名規則(Omniauth)と実定数(OmniAuth)が不一致なため除外
+    # lib/omniauth/strategies/line.rb は config/initializers/devise.rb で明示require
+    config.autoload_lib(ignore: %w[assets tasks omniauth])
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
## 🚨 緊急修正 (production down)

LINEログイン機能(#116)をmainにマージ後、Renderデプロイで起動失敗していたのを修正。

## 原因

\`lib/omniauth/strategies/line.rb\` をZeitwerkが eager_load しようとして、ディレクトリ名 \`omniauth\` から定数 \`Omniauth\` を期待した結果、実定義の \`OmniAuth\`(O・A両方大文字)と不一致でNameError。

\`\`\`
NameError: uninitialized constant Omniauth::Strategies::Line
\`\`\`

development環境では autoload + 明示require先行のため顕在化していなかった。

## 修正

\`config/application.rb\` の \`autoload_lib(ignore:)\` に \`omniauth\` を追加。
\`lib/omniauth/\` 配下はZeitwerkから除外し、\`config/initializers/devise.rb\` の明示requireのみで動作させる。

## 検証

- ✅ \`bin/rails zeitwerk:check\` → \`All is good!\`
- ✅ production env で \`Rails.application.eager_load!\` 成功
- ✅ development環境のLINEログイン動作は変わらず(明示requireが効いている)

## Test plan
- [ ] Renderへ自動デプロイされて起動成功すること
- [ ] 本番URLにアクセスしてトップページが表示されること
- [ ] 本番でLINEログインボタンが表示・動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)