### PR TITLE
fix: 人物詳細の「代表作」を「関連トピック」に名称変更

### DIFF
--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -57,12 +57,12 @@
         </div>
       </section>
 
-      <%# Key Works Section %>
+      <%# Related Topics Section %>
       <% if @character.events.any? %>
         <section class="flex flex-col gap-8">
           <div class="flex items-center gap-4">
             <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
-            <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">代表作 (Key Works)</h2>
+            <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">関連トピック (Related Topics)</h2>
           </div>
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-8">


### PR DESCRIPTION
## Summary
- 人物詳細ページのセクション「代表作 (Key Works)」を「関連トピック (Related Topics)」に変更
- セクションは `@character.events` を全件表示しているだけなので、実態と表記を揃えて誤解を防ぐ

## Test plan
- [ ] 人物詳細ページでセクションタイトルが「関連トピック (Related Topics)」になっている
- [ ] 表示されるカード(白カード/青カード)の内容と数は変わらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)