### PR TITLE
feat: 一般ユーザー向けページのモバイル対応

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -5,21 +5,45 @@ export default class extends Controller {
 
   toggle() {
     this.menuTarget.classList.toggle("hidden")
+    this.syncAria()
   }
 
   // メニュー外クリックで閉じる
   close(event) {
     if (!this.element.contains(event.target)) {
       this.menuTarget.classList.add("hidden")
+      this.syncAria()
     }
+  }
+
+  // ウィンドウリサイズで閉じる（モバイル↔PC切替時の状態不整合対策）
+  handleResize() {
+    if (this.menuTarget.classList.contains("hidden")) return
+    this.menuTarget.classList.add("hidden")
+    this.syncAria()
+  }
+
+  // 開閉状態をトグルボタンの aria-expanded に反映
+  syncAria() {
+    if (!this.toggleButton) return
+    const isOpen = !this.menuTarget.classList.contains("hidden")
+    this.toggleButton.setAttribute("aria-expanded", isOpen ? "true" : "false")
+  }
+
+  get toggleButton() {
+    return this.element.querySelector('[data-action*="dropdown#toggle"]')
   }
 
   connect() {
     this.boundClose = this.close.bind(this)
+    this.boundResize = this.handleResize.bind(this)
     document.addEventListener("click", this.boundClose)
+    window.addEventListener("resize", this.boundResize)
+    this.syncAria()
   }
 
   disconnect() {
     document.removeEventListener("click", this.boundClose)
+    window.removeEventListener("resize", this.boundResize)
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -36,3 +36,6 @@ application.register("sortable", SortableController)
 
 import AdminUsersConfirmModalController from "./admin_users/confirm_modal_controller"
 application.register("admin-users--confirm-modal", AdminUsersConfirmModalController)
+
+import TimelineSelectController from "./timeline_select_controller"
+application.register("timeline-select", TimelineSelectController)

--- a/app/javascript/controllers/timeline_select_controller.js
+++ b/app/javascript/controllers/timeline_select_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+// タイムライン単元選択: select変更で対応するURLへ遷移
+export default class extends Controller {
+  navigate(event) {
+    const url = event.target.value
+    if (url) {
+      window.location.href = url
+    }
+  }
+}

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,13 +1,13 @@
 <% provide(:title, "アカウント設定") %>
 
-<div class="max-w-[720px] mx-auto px-8 py-12">
-  <div class="mb-8">
-    <h1 class="text-[30px] font-medium text-[#0f172a]">アカウント設定</h1>
-    <p class="text-[16px] text-[#64748b] mt-1">パスワードの変更や退会の手続きができます。</p>
+<div class="max-w-[720px] mx-auto px-4 md:px-8 py-6 md:py-12">
+  <div class="mb-6 md:mb-8">
+    <h1 class="text-2xl md:text-[30px] font-medium text-[#0f172a]">アカウント設定</h1>
+    <p class="text-sm md:text-[16px] text-[#64748b] mt-1">パスワードの変更や退会の手続きができます。</p>
   </div>
 
   <%# プロフィール編集への導線 %>
-  <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-6 mb-6">
+  <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-5 md:p-6 mb-4 md:mb-6">
     <h2 class="text-[18px] font-medium text-[#0f172a] mb-2">プロフィール情報</h2>
     <p class="text-[14px] text-[#64748b] mb-4">ニックネームやメールアドレスを変更できます。</p>
     <%= link_to edit_user_registration_path, class: "inline-flex items-center gap-2 bg-white border border-[#e2e8f0] text-[#475569] text-[14px] font-medium px-4 py-2 rounded-lg hover:bg-[#f8fafc] transition" do %>
@@ -20,7 +20,7 @@
 
   <%# パスワード変更（通常ユーザーのみ） %>
   <% if current_user.password_changeable? %>
-    <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-6 mb-6">
+    <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-5 md:p-6 mb-4 md:mb-6">
       <h2 class="text-[18px] font-medium text-[#0f172a] mb-2">パスワード変更</h2>
       <p class="text-[14px] text-[#64748b] mb-6">現在のパスワードを入力してから、新しいパスワードを設定してください。</p>
 
@@ -63,7 +63,7 @@
   <% end %>
 
   <%# 退会 %>
-  <div class="bg-white border border-[#fecaca] rounded-lg shadow-sm p-6">
+  <div class="bg-white border border-[#fecaca] rounded-lg shadow-sm p-5 md:p-6">
     <h2 class="text-[18px] font-medium text-[#991b1b] mb-2">退会する</h2>
     <p class="text-[14px] text-[#64748b] mb-6">
       退会するとアカウントと関連データ（お気に入り、学習スケジュール、クイズ結果など）がすべて削除されます。この操作は取り消せません。

--- a/app/views/articles/_filter_sidebar.html.erb
+++ b/app/views/articles/_filter_sidebar.html.erb
@@ -1,4 +1,18 @@
-<aside class="w-64 shrink-0 flex flex-col gap-8">
+<aside class="w-full md:w-64 shrink-0" data-controller="dropdown">
+  <%# モバイル用 開閉トグル %>
+  <button type="button" data-action="click->dropdown#toggle" class="md:hidden w-full flex items-center justify-between px-4 py-3 bg-white border border-[#e2e8f0] rounded-lg">
+    <span class="text-sm font-medium text-[#0f172a] flex items-center gap-2">
+      <svg class="size-4 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/>
+      </svg>
+      フィルター
+    </span>
+    <svg class="size-4 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+    </svg>
+  </button>
+
+  <div data-dropdown-target="menu" class="hidden md:!flex flex-col gap-6 md:gap-8 mt-3 md:mt-0">
   <%= form_with url: articles_path, method: :get, local: true, data: { controller: "filter", action: "change->filter#submit" } do |f| %>
     <%# 検索キーワードとソートを保持 %>
     <%= hidden_field_tag "q[keyword]", params.dig(:q, :keyword) %>
@@ -53,4 +67,5 @@
     <%= link_to "フィルターをリセット", articles_path,
       class: "w-full border border-[#e2e8f0] rounded-lg py-2.5 text-sm text-[#64748b] hover:bg-[#f8fafc] text-center block" %>
   <% end %>
+  </div>
 </aside>

--- a/app/views/articles/_filter_sidebar.html.erb
+++ b/app/views/articles/_filter_sidebar.html.erb
@@ -1,6 +1,6 @@
 <aside class="w-full md:w-64 shrink-0" data-controller="dropdown">
   <%# モバイル用 開閉トグル %>
-  <button type="button" data-action="click->dropdown#toggle" class="md:hidden w-full flex items-center justify-between px-4 py-3 bg-white border border-[#e2e8f0] rounded-lg">
+  <button type="button" data-action="click->dropdown#toggle" aria-expanded="false" aria-controls="filter-panel" class="md:hidden w-full flex items-center justify-between px-4 py-3 bg-white border border-[#e2e8f0] rounded-lg">
     <span class="text-sm font-medium text-[#0f172a] flex items-center gap-2">
       <svg class="size-4 text-[#64748b]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/>
@@ -12,7 +12,7 @@
     </svg>
   </button>
 
-  <div data-dropdown-target="menu" class="hidden md:!flex flex-col gap-6 md:gap-8 mt-3 md:mt-0">
+  <div id="filter-panel" data-dropdown-target="menu" class="hidden md:!flex flex-col gap-6 md:gap-8 mt-3 md:mt-0">
   <%= form_with url: articles_path, method: :get, local: true, data: { controller: "filter", action: "change->filter#submit" } do |f| %>
     <%# 検索キーワードとソートを保持 %>
     <%= hidden_field_tag "q[keyword]", params.dig(:q, :keyword) %>

--- a/app/views/articles/_search_bar.html.erb
+++ b/app/views/articles/_search_bar.html.erb
@@ -1,9 +1,9 @@
-<div class="bg-white border-b border-[#e2e8f0] py-10 px-48">
-  <div class="max-w-[896px] w-full mx-auto px-4">
+<div class="bg-white border-b border-[#e2e8f0] py-6 md:py-10 px-4 md:px-8 lg:px-48">
+  <div class="max-w-[896px] w-full mx-auto">
     <%= form_with url: articles_path, method: :get, local: true do |f| %>
       <div class="relative">
         <div class="absolute inset-y-0 left-4 flex items-center">
-          <svg class="size-6 text-[#6b7280]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="size-5 md:size-6 text-[#6b7280]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
           </svg>
         </div>
@@ -11,7 +11,7 @@
           value: params.dig(:q, :keyword),
           name: "q[keyword]",
           placeholder: "出来事、人物、時代を検索...",
-          class: "w-full bg-white border-2 border-[#f1f5f9] rounded-lg pl-[50px] pr-[18px] py-5 text-lg text-[#6b7280] focus:outline-none focus:border-[#3713ec]" %>
+          class: "w-full bg-white border-2 border-[#f1f5f9] rounded-lg pl-12 md:pl-[50px] pr-4 md:pr-[18px] py-3 md:py-5 text-base md:text-lg text-[#6b7280] focus:outline-none focus:border-[#3713ec]" %>
       </div>
     <% end %>
   </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -4,19 +4,19 @@
 <%= render "articles/search_bar" %>
 
 <%# メインコンテンツ %>
-<div class="flex gap-8 px-8 py-8">
+<div class="flex flex-col md:flex-row gap-4 md:gap-8 px-4 md:px-8 py-6 md:py-8">
   <%# サイドバー %>
   <%= render "articles/filter_sidebar" %>
 
   <%# 記事一覧 %>
-  <div class="flex-1 flex flex-col gap-6">
+  <div class="flex-1 flex flex-col gap-4 md:gap-6 min-w-0">
     <%# 検索結果ヘッダー %>
-    <div class="flex items-center justify-between">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
       <p class="text-sm text-[#64748b]">
         検索結果: <span class="font-semibold text-[#0f172a]"><%= @articles.total_count %>件</span>
       </p>
       <%= form_with url: articles_path, method: :get, local: true, class: "flex items-center gap-2", data: { controller: "filter", action: "change->filter#submit" } do %>
-        <span class="text-sm text-[#64748b]">並び替え:</span>
+        <span class="text-sm text-[#64748b] shrink-0">並び替え:</span>
         <%# フィルター・検索パラメータを保持 %>
         <%= hidden_field_tag "q[keyword]", params.dig(:q, :keyword) %>
         <% params[:period_ids]&.each do |id| %>
@@ -29,12 +29,12 @@
             [["年代（古い順）", "year_asc"], ["年代（新しい順）", "year_desc"], ["名前順", "name_asc"]],
             params[:sort] || "year_asc"
           ),
-          class: "text-sm border border-[#e2e8f0] rounded-lg px-3 py-2" %>
+          class: "flex-1 sm:flex-none text-sm border border-[#e2e8f0] rounded-lg px-3 py-2" %>
       <% end %>
     </div>
 
     <%# カードグリッド %>
-    <div class="grid grid-cols-2 gap-6">
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
       <% @articles.each do |article| %>
         <%= render "articles/card", article: article %>
       <% end %>

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -12,30 +12,30 @@
     </div>
   <% end %>
   <div class="absolute inset-0 opacity-90" style="background-image: linear-gradient(154deg, rgb(0, 11, 96) 0%, rgb(20, 34, 131) 100%)"></div>
-  <div class="relative max-w-[1280px] mx-auto px-20 py-20 flex flex-col justify-center min-h-[500px]">
+  <div class="relative max-w-[1280px] mx-auto px-4 sm:px-8 md:px-12 lg:px-20 py-12 md:py-20 flex flex-col justify-center min-h-[320px] md:min-h-[500px]">
     <%# バッジ %>
-    <div class="pb-6 flex gap-3 items-center">
+    <div class="pb-4 md:pb-6 flex flex-wrap gap-2 md:gap-3 items-center">
       <% if user_signed_in? %>
-        <div class="mr-2">
+        <div class="mr-1 md:mr-2">
           <%= render "shared/favorite_button", article: @character %>
         </div>
       <% end %>
-      <span class="inline-flex items-center gap-2 bg-[rgba(236,119,0,0.2)] rounded-full px-4 py-1.5">
+      <span class="inline-flex items-center gap-2 bg-[rgba(236,119,0,0.2)] rounded-full px-3 md:px-4 py-1 md:py-1.5">
         <svg class="w-3 h-3 text-[#ec7700]" fill="currentColor" viewBox="0 0 20 20">
           <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
         </svg>
-        <span class="text-xs font-semibold tracking-[1.2px] uppercase text-[#ec7700]"><%= @character.period.name %> · <%= @character.region.name %></span>
+        <span class="text-[10px] md:text-xs font-semibold tracking-wider md:tracking-[1.2px] uppercase text-[#ec7700]"><%= @character.period.name %> · <%= @character.region.name %></span>
       </span>
     </div>
     <%# タイトル %>
-    <div class="pb-4">
-      <h1 class="text-[72px] font-extrabold text-white leading-[72px] tracking-[-3.6px]"><%= @character.name %></h1>
+    <div class="pb-2 md:pb-4">
+      <h1 class="text-3xl sm:text-4xl md:text-5xl lg:text-[72px] font-extrabold text-white leading-tight lg:leading-[72px] tracking-tight lg:tracking-[-3.6px]"><%= @character.name %></h1>
     </div>
     <%# 年代 %>
-    <p class="text-4xl font-normal text-white leading-[44px]">（<%= @character.year %>年）</p>
+    <p class="text-2xl md:text-3xl lg:text-4xl font-normal text-white leading-snug lg:leading-[44px]">（<%= @character.year %>年）</p>
   </div>
   <% if @character.image_credit.present? %>
-    <div class="absolute bottom-2 right-4 text-xs text-white/50">
+    <div class="absolute bottom-2 right-4 text-[10px] md:text-xs text-white/50">
       出典: <%= @character.image_credit %>
     </div>
   <% end %>
@@ -43,14 +43,14 @@
 
 <%# Main Content %>
 <div class="bg-[#eeeeee]">
-  <div class="max-w-[1280px] mx-auto px-8 py-20">
-    <div class="bg-white flex flex-col gap-20 p-12">
+  <div class="max-w-[1280px] mx-auto px-4 md:px-8 py-8 md:py-20">
+    <div class="bg-white flex flex-col gap-12 md:gap-20 p-5 md:p-12">
 
       <%# Overview Section %>
-      <section class="flex flex-col gap-8">
-        <div class="flex items-center gap-4">
-          <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
-          <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">概要 (Overview)</h2>
+      <section class="flex flex-col gap-5 md:gap-8">
+        <div class="flex items-center gap-3 md:gap-4">
+          <div class="w-1.5 h-9 md:h-12 bg-[#ec7700] rounded-full"></div>
+          <h2 class="text-xl md:text-2xl lg:text-[30px] font-bold text-[#191c1d] leading-snug lg:leading-9 tracking-tight lg:tracking-[-0.75px]">概要 (Overview)</h2>
         </div>
         <div class="flex flex-col gap-6">
           <%= render "shared/markdown_body", content: @character.description %>
@@ -59,27 +59,27 @@
 
       <%# Related Topics Section %>
       <% if @character.events.any? %>
-        <section class="flex flex-col gap-8">
-          <div class="flex items-center gap-4">
-            <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
-            <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">関連トピック (Related Topics)</h2>
+        <section class="flex flex-col gap-5 md:gap-8">
+          <div class="flex items-center gap-3 md:gap-4">
+            <div class="w-1.5 h-9 md:h-12 bg-[#ec7700] rounded-full"></div>
+            <h2 class="text-xl md:text-2xl lg:text-[30px] font-bold text-[#191c1d] leading-snug lg:leading-9 tracking-tight lg:tracking-[-0.75px]">関連トピック (Related Topics)</h2>
           </div>
 
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8">
             <%# 上段カード（白背景） %>
             <% @character.events.limit(2).each do |event| %>
-              <div class="bg-white rounded-xl p-8 shadow-[0px_24px_40px_-4px_rgba(25,28,29,0.06)] flex flex-col gap-2 overflow-hidden">
-                <p class="text-sm font-semibold tracking-[1.4px] uppercase text-[#ec7700] leading-5"><%= event.year %>年</p>
-                <h3 class="text-2xl font-bold text-[#191c1d] leading-8"><%= event.title %></h3>
+              <div class="bg-white rounded-xl p-5 md:p-8 shadow-[0px_24px_40px_-4px_rgba(25,28,29,0.06)] flex flex-col gap-2 overflow-hidden">
+                <p class="text-xs md:text-sm font-semibold tracking-wider md:tracking-[1.4px] uppercase text-[#ec7700] leading-5"><%= event.year %>年</p>
+                <h3 class="text-lg md:text-2xl font-bold text-[#191c1d] leading-snug md:leading-8"><%= event.title %></h3>
                 <div class="pt-2">
-                  <p class="text-base text-[#454652] leading-[26px] line-clamp-3"><%= markdown_to_plain(event.description) %></p>
+                  <p class="text-sm md:text-base text-[#454652] leading-relaxed md:leading-[26px] line-clamp-3"><%= markdown_to_plain(event.description) %></p>
                 </div>
                 <% if event.image.attached? %>
-                  <div class="h-52 rounded-lg overflow-hidden opacity-90 mt-2">
+                  <div class="h-40 md:h-52 rounded-lg overflow-hidden opacity-90 mt-2">
                     <%= image_tag event.image, class: "w-full h-full object-cover", alt: event.title %>
                   </div>
                 <% elsif event.image_url.present? %>
-                  <div class="h-52 rounded-lg overflow-hidden opacity-90 mt-2">
+                  <div class="h-40 md:h-52 rounded-lg overflow-hidden opacity-90 mt-2">
                     <%= image_tag event.image_url, class: "w-full h-full object-cover", alt: event.title %>
                   </div>
                 <% end %>
@@ -88,15 +88,15 @@
 
             <%# TODO: 本リリースで特集テーブルを作成し、特集カードのデータを管理する。現状はeventsの3件目以降を表示している。 %>
             <% @character.events.offset(2).each do |event| %>
-              <div class="md:col-span-2 bg-[#142283] rounded-xl p-8 shadow-[0px_24px_40px_-4px_rgba(25,28,29,0.06)] flex overflow-hidden h-80">
-                <div class="flex-1 flex flex-col gap-2 pr-8">
-                  <p class="text-sm font-semibold tracking-[1.4px] uppercase text-[#dfe0ff] leading-5"><%= event.year %>年</p>
-                  <h3 class="text-[30px] font-bold text-white leading-9"><%= event.title %></h3>
+              <div class="md:col-span-2 bg-[#142283] rounded-xl p-5 md:p-8 shadow-[0px_24px_40px_-4px_rgba(25,28,29,0.06)] flex flex-col md:flex-row overflow-hidden md:h-80 gap-4 md:gap-0">
+                <div class="flex-1 flex flex-col gap-2 md:pr-8 min-w-0">
+                  <p class="text-xs md:text-sm font-semibold tracking-wider md:tracking-[1.4px] uppercase text-[#dfe0ff] leading-5"><%= event.year %>年</p>
+                  <h3 class="text-xl md:text-2xl lg:text-[30px] font-bold text-white leading-snug lg:leading-9"><%= event.title %></h3>
                   <div class="pt-2">
-                    <p class="text-base text-[rgba(223,224,255,0.8)] leading-[26px] line-clamp-3"><%= markdown_to_plain(event.description) %></p>
+                    <p class="text-sm md:text-base text-[rgba(223,224,255,0.8)] leading-relaxed md:leading-[26px] line-clamp-3"><%= markdown_to_plain(event.description) %></p>
                   </div>
                 </div>
-                <div class="aspect-square h-full bg-white/10 rounded-lg flex items-center justify-center flex-shrink-0">
+                <div class="w-full md:w-auto md:aspect-square h-40 md:h-full bg-white/10 rounded-lg flex items-center justify-center flex-shrink-0">
                   <% if event.image.attached? %>
                     <%= image_tag event.image, class: "w-full h-full object-cover rounded-lg", alt: event.title %>
                   <% elsif event.image_url.present? %>
@@ -114,19 +114,19 @@
       <% end %>
 
       <%# Achievements Section %>
-      <section class="flex flex-col gap-8">
-        <div class="flex items-center gap-4">
-          <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
-          <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">業績 (Achievements)</h2>
+      <section class="flex flex-col gap-5 md:gap-8">
+        <div class="flex items-center gap-3 md:gap-4">
+          <div class="w-1.5 h-9 md:h-12 bg-[#ec7700] rounded-full"></div>
+          <h2 class="text-xl md:text-2xl lg:text-[30px] font-bold text-[#191c1d] leading-snug lg:leading-9 tracking-tight lg:tracking-[-0.75px]">業績 (Achievements)</h2>
         </div>
         <div class="flex flex-col gap-6">
-          <div class="bg-[#f3f4f5] rounded-xl p-6 flex gap-6 items-start">
+          <div class="bg-[#f3f4f5] rounded-xl p-4 md:p-6 flex gap-4 md:gap-6 items-start">
             <div class="flex-shrink-0">
-              <svg class="w-5 h-7 text-[#ec7700]" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="w-4 h-6 md:w-5 md:h-7 text-[#ec7700]" fill="currentColor" viewBox="0 0 20 20">
                 <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
               </svg>
             </div>
-            <div class="flex flex-col gap-2">
+            <div class="flex flex-col gap-2 min-w-0">
               <%= render "shared/markdown_body", content: @character.achievement %>
             </div>
           </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -12,33 +12,33 @@
     </div>
   <% end %>
   <div class="absolute inset-0 opacity-90" style="background-image: linear-gradient(154deg, rgb(0, 11, 96) 0%, rgb(20, 34, 131) 100%)"></div>
-  <div class="relative max-w-[1280px] mx-auto px-20 py-20 flex flex-col justify-center min-h-[500px]">
+  <div class="relative max-w-[1280px] mx-auto px-4 sm:px-8 md:px-12 lg:px-20 py-12 md:py-20 flex flex-col justify-center min-h-[320px] md:min-h-[500px]">
     <%# カテゴリ・時代バッジ %>
-    <div class="pb-6 flex gap-3 items-center">
+    <div class="pb-4 md:pb-6 flex flex-wrap gap-2 md:gap-3 items-center">
       <% if user_signed_in? %>
-        <div class="mr-2">
+        <div class="mr-1 md:mr-2">
           <%= render "shared/favorite_button", article: @event %>
         </div>
       <% end %>
-      <span class="inline-flex items-center gap-2 bg-[rgba(236,119,0,0.2)] rounded-full px-4 py-1.5">
-        <span class="text-xs font-semibold tracking-[1.2px] uppercase text-[#ec7700]"><%= @event.category.name %></span>
+      <span class="inline-flex items-center gap-2 bg-[rgba(236,119,0,0.2)] rounded-full px-3 md:px-4 py-1 md:py-1.5">
+        <span class="text-[10px] md:text-xs font-semibold tracking-wider md:tracking-[1.2px] uppercase text-[#ec7700]"><%= @event.category.name %></span>
       </span>
-      <span class="inline-flex items-center gap-2 bg-white/10 rounded-full px-4 py-1.5">
+      <span class="inline-flex items-center gap-2 bg-white/10 rounded-full px-3 md:px-4 py-1 md:py-1.5">
         <svg class="w-3 h-3 text-white/70" fill="currentColor" viewBox="0 0 20 20">
           <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
         </svg>
-        <span class="text-xs font-semibold tracking-[1.2px] uppercase text-white/70"><%= @event.period.name %> · <%= @event.region.name %></span>
+        <span class="text-[10px] md:text-xs font-semibold tracking-wider md:tracking-[1.2px] uppercase text-white/70"><%= @event.period.name %> · <%= @event.region.name %></span>
       </span>
     </div>
     <%# タイトル %>
-    <div class="pb-4">
-      <h1 class="text-[72px] font-extrabold text-white leading-[72px] tracking-[-3.6px]"><%= @event.title %></h1>
+    <div class="pb-2 md:pb-4">
+      <h1 class="text-3xl sm:text-4xl md:text-5xl lg:text-[72px] font-extrabold text-white leading-tight lg:leading-[72px] tracking-tight lg:tracking-[-3.6px]"><%= @event.title %></h1>
     </div>
     <%# 年代 %>
-    <p class="text-4xl font-normal text-white leading-[44px] mt-4"><%= @event.year %>年</p>
+    <p class="text-2xl md:text-3xl lg:text-4xl font-normal text-white leading-snug lg:leading-[44px] mt-2 md:mt-4"><%= @event.year %>年</p>
   </div>
   <% if @event.image_credit.present? %>
-    <div class="absolute bottom-2 right-4 text-xs text-white/50">
+    <div class="absolute bottom-2 right-4 text-[10px] md:text-xs text-white/50">
       出典: <%= @event.image_credit %>
     </div>
   <% end %>
@@ -46,14 +46,14 @@
 
 <%# Main Content %>
 <div class="bg-[#eeeeee]">
-  <div class="max-w-[1280px] mx-auto px-8 py-20">
-    <div class="bg-white flex flex-col gap-20 p-12">
+  <div class="max-w-[1280px] mx-auto px-4 md:px-8 py-8 md:py-20">
+    <div class="bg-white flex flex-col gap-12 md:gap-20 p-5 md:p-12">
 
       <%# Overview Section %>
-      <section class="flex flex-col gap-8">
-        <div class="flex items-center gap-4">
-          <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
-          <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">概要 (Overview)</h2>
+      <section class="flex flex-col gap-5 md:gap-8">
+        <div class="flex items-center gap-3 md:gap-4">
+          <div class="w-1.5 h-9 md:h-12 bg-[#ec7700] rounded-full"></div>
+          <h2 class="text-xl md:text-2xl lg:text-[30px] font-bold text-[#191c1d] leading-snug lg:leading-9 tracking-tight lg:tracking-[-0.75px]">概要 (Overview)</h2>
         </div>
         <div class="flex flex-col gap-6">
           <%= render "shared/markdown_body", content: @event.description %>
@@ -62,33 +62,33 @@
 
       <%# Key Characters Section %>
       <% if @event.characters.any? %>
-        <section class="flex flex-col gap-8">
-          <div class="flex items-center gap-4">
-            <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
-            <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">関連人物 (Key Characters)</h2>
+        <section class="flex flex-col gap-5 md:gap-8">
+          <div class="flex items-center gap-3 md:gap-4">
+            <div class="w-1.5 h-9 md:h-12 bg-[#ec7700] rounded-full"></div>
+            <h2 class="text-xl md:text-2xl lg:text-[30px] font-bold text-[#191c1d] leading-snug lg:leading-9 tracking-tight lg:tracking-[-0.75px]">関連人物 (Key Characters)</h2>
           </div>
 
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8">
             <% @event.characters.each do |character| %>
               <%= link_to character_path(character), class: "block" do %>
-                <div class="bg-[#f3f4f5] rounded-xl p-6 flex gap-6 items-start hover:shadow-md transition-shadow">
+                <div class="bg-[#f3f4f5] rounded-xl p-4 md:p-6 flex gap-4 md:gap-6 items-start hover:shadow-md transition-shadow">
                   <% if character.image.attached? %>
-                    <div class="w-16 h-16 rounded-full overflow-hidden flex-shrink-0">
+                    <div class="w-14 h-14 md:w-16 md:h-16 rounded-full overflow-hidden flex-shrink-0">
                       <%= image_tag character.image, class: "w-full h-full object-cover", alt: character.name %>
                     </div>
                   <% elsif character.image_url.present? %>
-                    <div class="w-16 h-16 rounded-full overflow-hidden flex-shrink-0">
+                    <div class="w-14 h-14 md:w-16 md:h-16 rounded-full overflow-hidden flex-shrink-0">
                       <%= image_tag character.image_url, class: "w-full h-full object-cover", alt: character.name %>
                     </div>
                   <% else %>
-                    <div class="w-16 h-16 rounded-full bg-[#142283] flex items-center justify-center flex-shrink-0">
-                      <span class="text-white text-xl font-bold"><%= character.name.first %></span>
+                    <div class="w-14 h-14 md:w-16 md:h-16 rounded-full bg-[#142283] flex items-center justify-center flex-shrink-0">
+                      <span class="text-white text-lg md:text-xl font-bold"><%= character.name.first %></span>
                     </div>
                   <% end %>
-                  <div class="flex flex-col gap-1">
-                    <h3 class="text-xl font-bold text-[#191c1d]"><%= character.name %></h3>
+                  <div class="flex flex-col gap-1 min-w-0">
+                    <h3 class="text-lg md:text-xl font-bold text-[#191c1d]"><%= character.name %></h3>
                     <p class="text-sm text-[#ec7700] font-semibold"><%= character.year %>年</p>
-                    <p class="text-base text-[#454652] leading-[26px] line-clamp-2"><%= markdown_to_plain(character.description) %></p>
+                    <p class="text-sm md:text-base text-[#454652] leading-relaxed md:leading-[26px] line-clamp-2"><%= markdown_to_plain(character.description) %></p>
                   </div>
                 </div>
               <% end %>
@@ -98,23 +98,23 @@
       <% end %>
 
       <%# Details Section %>
-      <section class="flex flex-col gap-8">
-        <div class="flex items-center gap-4">
-          <div class="w-1.5 h-12 bg-[#ec7700] rounded-full"></div>
-          <h2 class="text-[30px] font-bold text-[#191c1d] leading-9 tracking-[-0.75px]">詳細情報 (Details)</h2>
+      <section class="flex flex-col gap-5 md:gap-8">
+        <div class="flex items-center gap-3 md:gap-4">
+          <div class="w-1.5 h-9 md:h-12 bg-[#ec7700] rounded-full"></div>
+          <h2 class="text-xl md:text-2xl lg:text-[30px] font-bold text-[#191c1d] leading-snug lg:leading-9 tracking-tight lg:tracking-[-0.75px]">詳細情報 (Details)</h2>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div class="bg-[#f3f4f5] rounded-xl p-6">
-            <p class="text-xs font-semibold text-[#9ca3af] tracking-[1.2px] uppercase mb-2">時代</p>
-            <p class="text-lg font-bold text-[#191c1d]"><%= @event.period.name %></p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 md:gap-6">
+          <div class="bg-[#f3f4f5] rounded-xl p-4 md:p-6">
+            <p class="text-xs font-semibold text-[#9ca3af] tracking-wider md:tracking-[1.2px] uppercase mb-1 md:mb-2">時代</p>
+            <p class="text-base md:text-lg font-bold text-[#191c1d]"><%= @event.period.name %></p>
           </div>
-          <div class="bg-[#f3f4f5] rounded-xl p-6">
-            <p class="text-xs font-semibold text-[#9ca3af] tracking-[1.2px] uppercase mb-2">地域</p>
-            <p class="text-lg font-bold text-[#191c1d]"><%= @event.region.name %></p>
+          <div class="bg-[#f3f4f5] rounded-xl p-4 md:p-6">
+            <p class="text-xs font-semibold text-[#9ca3af] tracking-wider md:tracking-[1.2px] uppercase mb-1 md:mb-2">地域</p>
+            <p class="text-base md:text-lg font-bold text-[#191c1d]"><%= @event.region.name %></p>
           </div>
-          <div class="bg-[#f3f4f5] rounded-xl p-6">
-            <p class="text-xs font-semibold text-[#9ca3af] tracking-[1.2px] uppercase mb-2">学習単元</p>
-            <p class="text-lg font-bold text-[#191c1d]"><%= @event.study_unit.name %></p>
+          <div class="bg-[#f3f4f5] rounded-xl p-4 md:p-6 sm:col-span-2 md:col-span-1">
+            <p class="text-xs font-semibold text-[#9ca3af] tracking-wider md:tracking-[1.2px] uppercase mb-1 md:mb-2">学習単元</p>
+            <p class="text-base md:text-lg font-bold text-[#191c1d]"><%= @event.study_unit.name %></p>
           </div>
         </div>
       </section>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,28 +1,28 @@
 <% provide(:title, "お気に入り") %>
 
-<div class="max-w-[1280px] mx-auto px-8 py-12">
-  <div class="mb-8">
-    <h1 class="text-[30px] font-medium text-[#0f172a]">お気に入り</h1>
-    <p class="text-[16px] text-[#64748b] mt-1"><%= @articles.total_count %>件の記事</p>
+<div class="max-w-[1280px] mx-auto px-4 md:px-8 py-6 md:py-12">
+  <div class="mb-6 md:mb-8">
+    <h1 class="text-2xl md:text-[30px] font-medium text-[#0f172a]">お気に入り</h1>
+    <p class="text-sm md:text-[16px] text-[#64748b] mt-1"><%= @articles.total_count %>件の記事</p>
   </div>
 
   <% if @articles.any? %>
-    <div class="grid grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
       <% @articles.each do |article| %>
         <%= render "articles/card", article: article %>
       <% end %>
     </div>
 
-    <div class="mt-8">
+    <div class="mt-6 md:mt-8">
       <%= paginate @articles, outer_window: 1, inner_window: 1, theme: "articles" %>
     </div>
   <% else %>
-    <div class="text-center py-20">
-      <svg class="mx-auto size-16 text-[#cbd5e1]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <div class="text-center py-12 md:py-20">
+      <svg class="mx-auto size-14 md:size-16 text-[#cbd5e1]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
       </svg>
-      <p class="text-[#64748b] mt-4 text-lg">お気に入りの記事はまだありません</p>
-      <%= link_to "記事一覧を見る", articles_path, class: "inline-block mt-4 text-[#3713ec] hover:underline" %>
+      <p class="text-[#64748b] mt-3 md:mt-4 text-base md:text-lg">お気に入りの記事はまだありません</p>
+      <%= link_to "記事一覧を見る", articles_path, class: "inline-block mt-3 md:mt-4 text-sm md:text-base text-[#3713ec] hover:underline" %>
     </div>
   <% end %>
 </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
+    <meta charset="utf-8">
     <title>管理画面 - Culture Link</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
+    <meta charset="utf-8">
     <title><%= page_title %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%# Turboのリンク先読み(prefetch)を無効化: article_viewsの記録が実クリックと一致しないため %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,24 +1,24 @@
 <% provide(:title, "マイページ") %>
 
-<div class="max-w-[1280px] mx-auto px-8 py-12">
+<div class="max-w-[1280px] mx-auto px-4 md:px-8 py-6 md:py-12">
   <%# ウェルカムメッセージ %>
-  <div class="mb-8 flex items-start justify-between">
+  <div class="mb-6 md:mb-8 flex flex-col md:flex-row md:items-start md:justify-between gap-4">
     <div>
-      <h1 class="text-[30px] font-medium text-[#0f172a]">
+      <h1 class="text-2xl md:text-[30px] font-medium text-[#0f172a]">
         おかえりなさい、<%= current_user.name %>さん！ 👋
       </h1>
-      <p class="text-[16px] text-[#64748b] mt-1">
+      <p class="text-sm md:text-[16px] text-[#64748b] mt-1">
         順調ですね！今日は3つの学習セッションが予定されています。
       </p>
     </div>
-    <div class="flex items-center gap-3 shrink-0">
-      <%= link_to edit_user_registration_path, class: "flex items-center gap-2 bg-white border border-[#e2e8f0] text-[#475569] text-[14px] font-medium px-4 py-2 rounded-lg hover:bg-[#f8fafc] transition" do %>
+    <div class="flex items-center gap-2 md:gap-3 shrink-0 flex-wrap">
+      <%= link_to edit_user_registration_path, class: "flex items-center gap-2 bg-white border border-[#e2e8f0] text-[#475569] text-xs md:text-[14px] font-medium px-3 md:px-4 py-2 rounded-lg hover:bg-[#f8fafc] transition" do %>
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
         </svg>
         プロフィール編集
       <% end %>
-      <%= link_to account_path, class: "flex items-center gap-2 bg-white border border-[#e2e8f0] text-[#475569] text-[14px] font-medium px-4 py-2 rounded-lg hover:bg-[#f8fafc] transition" do %>
+      <%= link_to account_path, class: "flex items-center gap-2 bg-white border border-[#e2e8f0] text-[#475569] text-xs md:text-[14px] font-medium px-3 md:px-4 py-2 rounded-lg hover:bg-[#f8fafc] transition" do %>
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
@@ -57,7 +57,7 @@
 
     <% if @quiz_result_pages.any? %>
       <% @quiz_result_pages.each_with_index do |page_results, page_index| %>
-        <div class="<%= 'hidden' unless page_index == 0 %> grid grid-cols-3 gap-6" data-card-pagination-target="page">
+        <div class="<%= 'hidden' unless page_index == 0 %> grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6" data-card-pagination-target="page">
           <% page_results.each do |result| %>
             <% color = quiz_result_color(result.score) %>
             <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-6 flex items-center justify-between">
@@ -92,9 +92,9 @@
   </div>
 
   <%# スケジュール＋最近チェックした項目 %>
-  <div class="grid grid-cols-3 gap-8">
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 md:gap-8">
     <%# 今後の学習スケジュール（2カラム分） %>
-    <div class="col-span-2">
+    <div class="lg:col-span-2">
       <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm overflow-hidden" data-controller="card-pagination">
         <%# ヘッダー %>
         <div class="flex items-center justify-between px-6 py-6 border-b border-[#f1f5f9]">
@@ -234,7 +234,7 @@
     </div>
 
     <%# 最近チェックした項目 %>
-    <div class="col-span-1">
+    <div class="lg:col-span-1">
       <div class="bg-white border border-[#e2e8f0] rounded-lg shadow-sm">
         <div class="px-6 py-6 border-b border-[#f1f5f9]">
           <h2 class="text-[18px] font-medium text-[#0f172a]">最近チェックした項目</h2>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: schedule, class: "relative bg-white rounded-[32px] shadow-[0px_25px_50px_-12px_rgba(0,11,96,0.05)] px-12 pt-12 pb-16 overflow-hidden",
+<%= form_with(model: schedule, class: "relative bg-white rounded-2xl md:rounded-[32px] shadow-[0px_25px_50px_-12px_rgba(0,11,96,0.05)] px-5 pt-6 pb-8 md:px-12 md:pt-12 md:pb-16 overflow-hidden",
   data: { controller: "schedule-form" }) do |f| %>
 
   <%# 装飾用アクセント %>
@@ -16,16 +16,16 @@
     </div>
   <% end %>
 
-  <div class="flex flex-col gap-10 relative">
+  <div class="flex flex-col gap-7 md:gap-10 relative">
     <%# === 学習期間セクション === %>
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-2">
         <svg class="w-[18px] h-[20px] text-[#ec7700]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
         </svg>
-        <span class="text-[18px] font-medium text-[#000b60]">学習期間</span>
+        <span class="text-base md:text-[18px] font-medium text-[#000b60]">学習期間</span>
       </div>
-      <div class="grid grid-cols-2 gap-6">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
         <div class="flex flex-col gap-2">
           <label class="text-[12px] text-[#767683] uppercase tracking-wider">開始日</label>
           <%= f.date_field :start_date,
@@ -45,7 +45,7 @@
         <svg class="w-[20px] h-[20px] text-[#ec7700]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
         </svg>
-        <span class="text-[18px] font-medium text-[#000b60]">1日の目標学習時間</span>
+        <span class="text-base md:text-[18px] font-medium text-[#000b60]">1日の目標学習時間</span>
       </div>
       <div class="max-w-[320px]">
         <%= f.select :daily_study_hours,
@@ -62,16 +62,16 @@
         <svg class="w-[21px] h-[22px] text-[#ec7700]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
         </svg>
-        <span class="text-[18px] font-medium text-[#000b60]">週間スケジュール</span>
+        <span class="text-base md:text-[18px] font-medium text-[#000b60]">週間スケジュール</span>
       </div>
-      <div class="flex gap-3" data-controller="weekday-toggle">
+      <div class="flex justify-between md:justify-start md:gap-3" data-controller="weekday-toggle">
         <input type="hidden" name="schedule[weekdays][]" value="">
         <% %w[月 火 水 木 金 土 日].each_with_index do |day, index| %>
           <label class="cursor-pointer" data-weekday-toggle-target="label">
             <input type="checkbox" name="schedule[weekdays][]" value="<%= index %>"
               class="hidden" data-weekday-toggle-target="checkbox" data-action="change->weekday-toggle#toggle"
               <%= "checked" if schedule.weekdays&.include?(index) %>>
-            <span class="inline-flex items-center justify-center w-[52px] h-[38px] rounded-full text-[14px] font-medium transition-colors"
+            <span class="inline-flex items-center justify-center w-10 h-10 md:w-[52px] md:h-[38px] rounded-full text-sm md:text-[14px] font-medium transition-colors"
               data-weekday-toggle-target="display">
               <%= day %>
             </span>
@@ -86,7 +86,7 @@
         <svg class="w-[19px] h-[16px] text-[#ec7700]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
         </svg>
-        <span class="text-[18px] font-medium text-[#000b60]">学習ユニットの選択</span>
+        <span class="text-base md:text-[18px] font-medium text-[#000b60]">学習ユニットの選択</span>
       </div>
 
       <%# 選択済みタグ %>
@@ -129,7 +129,7 @@
         <svg class="w-[18px] h-[16px] text-[#ec7700]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
         </svg>
-        <span class="text-[18px] font-medium text-[#000b60]">学習メモ・目標</span>
+        <span class="text-base md:text-[18px] font-medium text-[#000b60]">学習メモ・目標</span>
       </div>
       <%= f.text_area :memo,
         placeholder: "この期間に達成したいことや、自分へのメモを記入してください...",
@@ -138,11 +138,11 @@
     </div>
 
     <%# === アクションボタン === %>
-    <div class="flex gap-4 pt-8">
+    <div class="flex flex-col-reverse sm:flex-row gap-3 sm:gap-4 pt-6 md:pt-8">
       <%= link_to "キャンセル", profile_path,
-        class: "flex-1 text-center py-5 bg-[#e7e8e9] text-[#48626e] text-[16px] font-medium rounded-full hover:bg-[#d9dadb] transition" %>
+        class: "flex-1 text-center py-3 md:py-5 bg-[#e7e8e9] text-[#48626e] text-sm md:text-[16px] font-medium rounded-full hover:bg-[#d9dadb] transition" %>
       <%= f.submit schedule.persisted? ? "スケジュールを更新する" : "スケジュールを保存する",
-        class: "flex-1 py-5 bg-gradient-to-r from-[#ec7700] to-[#ea580c] text-white text-[16px] font-medium rounded-full shadow-[0px_20px_25px_-5px_rgba(249,115,22,0.2),0px_8px_10px_-6px_rgba(249,115,22,0.2)] hover:opacity-90 transition cursor-pointer" %>
+        class: "flex-1 py-3 md:py-5 bg-gradient-to-r from-[#ec7700] to-[#ea580c] text-white text-sm md:text-[16px] font-medium rounded-full shadow-[0px_20px_25px_-5px_rgba(249,115,22,0.2),0px_8px_10px_-6px_rgba(249,115,22,0.2)] hover:opacity-90 transition cursor-pointer" %>
     </div>
   </div>
 <% end %>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,12 +1,12 @@
 <% provide(:title, "学習スケジュール編集") %>
 
-<div class="max-w-[960px] mx-auto px-8 pt-24 pb-20">
+<div class="max-w-[960px] mx-auto px-4 md:px-8 pt-10 md:pt-24 pb-12 md:pb-20">
   <%# ヘッダーセクション %>
-  <div class="mb-12">
-    <h1 class="text-[36px] font-medium text-[#000b60] tracking-tight leading-tight">
+  <div class="mb-6 md:mb-12">
+    <h1 class="text-2xl md:text-[36px] font-medium text-[#000b60] tracking-tight leading-tight">
       学習スケジュールの編集
     </h1>
-    <p class="text-[16px] text-[#454652] mt-3">
+    <p class="text-sm md:text-[16px] text-[#454652] mt-2 md:mt-3">
       スケジュールの内容を変更できます。
     </p>
   </div>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,12 +1,12 @@
 <% provide(:title, "学習スケジュール設定") %>
 
-<div class="max-w-[960px] mx-auto px-8 pt-24 pb-20">
+<div class="max-w-[960px] mx-auto px-4 md:px-8 pt-10 md:pt-24 pb-12 md:pb-20">
   <%# ヘッダーセクション %>
-  <div class="mb-12">
-    <h1 class="text-[36px] font-medium text-[#000b60] tracking-tight leading-tight">
+  <div class="mb-6 md:mb-12">
+    <h1 class="text-2xl md:text-[36px] font-medium text-[#000b60] tracking-tight leading-tight">
       学習スケジュールの設定
     </h1>
-    <p class="text-[16px] text-[#454652] mt-3">
+    <p class="text-sm md:text-[16px] text-[#454652] mt-2 md:mt-3">
       自分のペースに合わせて、最適な歴史探究プランを作成しましょう。
     </p>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,7 +16,7 @@
     <nav class="hidden md:flex items-center gap-6 lg:gap-8">
       <%= link_to "記事一覧", articles_path, class: "text-[14px] text-[#475569] font-medium hover:text-[#0f172a]" %>
       <div class="relative" data-controller="dropdown">
-        <button type="button" data-action="click->dropdown#toggle" class="text-[14px] text-[#475569] font-medium hover:text-[#0f172a] flex items-center gap-1">
+        <button type="button" data-action="click->dropdown#toggle" aria-expanded="false" aria-haspopup="true" class="text-[14px] text-[#475569] font-medium hover:text-[#0f172a] flex items-center gap-1">
           タイムライン
           <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
@@ -46,7 +46,7 @@
 
     <%# モバイル: ハンバーガーメニュー %>
     <div class="md:hidden" data-controller="dropdown">
-      <button type="button" data-action="click->dropdown#toggle" aria-label="メニュー" class="p-2 -mr-2 text-[#475569] hover:text-[#0f172a]">
+      <button type="button" data-action="click->dropdown#toggle" aria-label="メニュー" aria-expanded="false" class="p-2 -mr-2 text-[#475569] hover:text-[#0f172a]">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
         </svg>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,19 +1,19 @@
-<header class="bg-white border-b border-[#e2e8f0] w-full">
-  <div class="h-[80px] px-4 flex items-center justify-between">
+<header class="bg-white border-b border-[#e2e8f0] w-full relative">
+  <div class="h-16 md:h-[80px] px-4 flex items-center justify-between">
     <%# ロゴ %>
     <%= link_to root_path, class: "flex items-center gap-2" do %>
-      <div class="bg-[#3713ec] rounded-lg flex items-center justify-center size-10">
-        <svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <div class="bg-[#3713ec] rounded-lg flex items-center justify-center size-8 md:size-10">
+        <svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 md:w-5 md:h-5">
           <path d="M8.66602 8.66675L6.66602 6.66675V4.00008L12.666 6.66675M12.666 6.66675C12.666 9.97824 9.97751 12.6667 6.66602 12.6667C3.35453 12.6667 0.666016 9.97824 0.666016 6.66675C0.666016 3.35526 3.35453 0.666748 6.66602 0.666748C9.97751 0.666748 12.666 3.35526 12.666 6.66675Z" stroke="white" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </div>
-      <span class="font-bold text-[20px] text-[#0f172a] tracking-[-0.5px]" style="font-family: 'Lexend', sans-serif;">
+      <span class="font-bold text-base md:text-[20px] text-[#0f172a] tracking-[-0.5px]" style="font-family: 'Lexend', sans-serif;">
         culture-link
       </span>
     <% end %>
 
-    <%# ナビゲーション %>
-    <nav class="flex items-center gap-8">
+    <%# デスクトップナビ %>
+    <nav class="hidden md:flex items-center gap-6 lg:gap-8">
       <%= link_to "記事一覧", articles_path, class: "text-[14px] text-[#475569] font-medium hover:text-[#0f172a]" %>
       <div class="relative" data-controller="dropdown">
         <button type="button" data-action="click->dropdown#toggle" class="text-[14px] text-[#475569] font-medium hover:text-[#0f172a] flex items-center gap-1">
@@ -43,5 +43,45 @@
         <%= link_to "会員登録", new_user_registration_path, class: "bg-[#3713ec] text-white text-[14px] font-medium px-5 py-2 rounded-lg shadow-[0px_4px_6px_-1px_rgba(55,19,236,0.2),0px_2px_4px_-2px_rgba(55,19,236,0.2)] hover:opacity-90" %>
       <% end %>
     </nav>
+
+    <%# モバイル: ハンバーガーメニュー %>
+    <div class="md:hidden" data-controller="dropdown">
+      <button type="button" data-action="click->dropdown#toggle" aria-label="メニュー" class="p-2 -mr-2 text-[#475569] hover:text-[#0f172a]">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+        </svg>
+      </button>
+      <div data-dropdown-target="menu" class="hidden absolute top-full left-0 right-0 bg-white border-t border-[#e2e8f0] shadow-lg z-50 max-h-[calc(100vh-4rem)] overflow-y-auto">
+        <nav class="flex flex-col py-2">
+          <%= link_to "記事一覧", articles_path, class: "px-4 py-3 text-sm text-[#475569] font-medium hover:bg-[#f8fafc] hover:text-[#0f172a]" %>
+          <div class="px-4 py-3 border-t border-[#f1f5f9]">
+            <p class="text-xs font-bold text-[#94a3b8] uppercase tracking-wider mb-2">タイムライン</p>
+            <% StudyUnit.ordered.each do |unit| %>
+              <%= link_to unit.name, timeline_path(unit), class: "block py-2 text-sm text-[#475569] hover:text-[#0f172a]" %>
+            <% end %>
+          </div>
+          <% if user_signed_in? %>
+            <% if current_user.admin? %>
+              <div class="px-4 py-3 border-t border-[#f1f5f9]">
+                <%= link_to "管理画面", admin_root_path, class: "inline-block text-sm text-white font-medium bg-[#0058be] px-4 py-2 rounded-lg" %>
+              </div>
+            <% end %>
+            <%= link_to "小テスト", quizzes_path, class: "px-4 py-3 text-sm text-[#475569] font-medium hover:bg-[#f8fafc] hover:text-[#0f172a] border-t border-[#f1f5f9]" %>
+            <%= link_to "スケジュール", new_schedule_path, class: "px-4 py-3 text-sm text-[#475569] font-medium hover:bg-[#f8fafc] hover:text-[#0f172a]" %>
+            <%= link_to "お気に入り", favorites_path, class: "px-4 py-3 text-sm text-[#475569] font-medium hover:bg-[#f8fafc] hover:text-[#0f172a]" %>
+            <%= link_to "#{current_user.name}さん", profile_path, class: "px-4 py-3 text-sm text-[#475569] font-medium hover:bg-[#f8fafc] hover:text-[#0f172a]" %>
+            <div class="px-4 py-3 border-t border-[#f1f5f9]">
+              <%= button_to "ログアウト", destroy_user_session_path, method: :delete,
+                  class: "text-sm text-[#475569] font-medium hover:text-[#0f172a] cursor-pointer" %>
+            </div>
+          <% else %>
+            <%= link_to "ログイン", new_user_session_path, class: "px-4 py-3 text-sm text-[#475569] font-medium hover:bg-[#f8fafc] hover:text-[#0f172a] border-t border-[#f1f5f9]" %>
+            <div class="px-4 py-3">
+              <%= link_to "会員登録", new_user_registration_path, class: "block bg-[#3713ec] text-white text-sm font-medium px-5 py-2 rounded-lg text-center" %>
+            </div>
+          <% end %>
+        </nav>
+      </div>
+    </div>
   </div>
 </header>

--- a/app/views/shared/_timeline_card.html.erb
+++ b/app/views/shared/_timeline_card.html.erb
@@ -1,0 +1,16 @@
+<%# locals: (event:, card_class: "") %>
+<%= link_to event_path(event), class: "block #{card_class}" do %>
+  <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm p-4 md:p-6 flex flex-col hover:shadow-md transition-shadow">
+    <div class="mb-2">
+      <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-wider md:tracking-[0.25px] uppercase" style="<%= category_badge_style(event.category) %>">
+        <%= event.category.name %>
+      </span>
+    </div>
+    <h3 class="text-base md:text-lg font-medium text-[#111827] mb-1"><%= event.title %></h3>
+    <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
+    <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= markdown_to_plain(event.description) %></p>
+    <% if event.characters.any? %>
+      <p class="text-xs md:text-sm text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,22 +1,22 @@
 <%# ヒーローセクション %>
-<section class="bg-[#f8fafc] py-24 px-8">
-  <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
+<section class="bg-[#f8fafc] py-12 md:py-24 px-4 md:px-8">
+  <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 items-center">
     <%# テキストコンテンツ %>
-    <div class="flex flex-col gap-6">
-      <h1 class="text-5xl md:text-6xl font-bold text-[#0f172a] leading-tight">
+    <div class="flex flex-col gap-4 md:gap-6">
+      <h1 class="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-[#0f172a] leading-tight">
         歴史を<span class="text-[#3713ec]">「つながり」</span><br>でマスターする
       </h1>
-      <p class="text-lg text-[#475569] leading-relaxed max-w-xl">
+      <p class="text-base md:text-lg text-[#475569] leading-relaxed max-w-xl">
         年号や暗記だけの学習はもう終わり。ビジュアルタイムラインで、文明、芸術、革新の隠れたつながりを発見しましょう。
       </p>
-      <div class="pt-4">
+      <div class="pt-2 md:pt-4">
         <%= link_to "無料で学習を始める", articles_path,
-          class: "inline-block bg-[#3713ec] text-white text-lg font-medium px-8 py-4 rounded-lg shadow-[0px_20px_25px_0px_rgba(55,19,236,0.25),0px_8px_10px_0px_rgba(55,19,236,0.25)] hover:opacity-90 transition" %>
+          class: "inline-block bg-[#3713ec] text-white text-base md:text-lg font-medium px-6 md:px-8 py-3 md:py-4 rounded-lg shadow-[0px_20px_25px_0px_rgba(55,19,236,0.25),0px_8px_10px_0px_rgba(55,19,236,0.25)] hover:opacity-90 transition" %>
       </div>
     </div>
     <%# イラスト %>
-    <div class="flex justify-center">
-      <%= image_tag "/toppage_icon.png", alt: "文化史学習のイラスト", class: "w-full max-w-md" %>
+    <div class="flex justify-center order-first md:order-last">
+      <%= image_tag "/toppage_icon.png", alt: "文化史学習のイラスト", class: "w-full max-w-xs md:max-w-md" %>
     </div>
   </div>
 </section>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -1,8 +1,8 @@
 <% provide(:title, @study_unit.name) %>
 
-<div class="flex flex-col md:flex-row h-[calc(100vh-64px)] md:h-[calc(100vh-80px)]">
+<div class="flex flex-col md:flex-row min-h-[calc(100vh-64px)] md:h-[calc(100vh-80px)] md:min-h-0">
   <%# モバイル用: 単元選択 + 凡例 %>
-  <div class="md:hidden bg-white border-b border-[#e5e7eb] px-4 py-3 flex-shrink-0 flex flex-col gap-3">
+  <div class="md:hidden bg-white border-b border-[#e5e7eb] px-4 py-3 flex-shrink-0 flex flex-col gap-3 sticky top-0 z-20">
     <%= form_tag "", method: :get, class: "flex gap-2 items-center" do %>
       <label class="text-xs font-medium text-[#9ca3af] tracking-wider uppercase shrink-0">単元</label>
       <%= select_tag :unit, options_for_select(@study_units.map { |u| [u.name, timeline_path(u)] }, timeline_path(@study_unit)),
@@ -45,68 +45,105 @@
   </aside>
 
   <%# メインエリア %>
-  <div class="flex-1 bg-[#fafafa] flex flex-col overflow-hidden">
-    <%# ヘッダー (デスクトップのみ表示) %>
-    <div class="hidden md:block backdrop-blur-sm bg-white/50 border-b border-[#e5e7eb] px-6 py-4 flex-shrink-0">
-      <div class="flex items-center justify-between">
-        <div>
-          <h1 class="text-xl font-medium text-black tracking-[3.2px]"><%= @study_unit.name %></h1>
+  <div class="flex-1 bg-[#fafafa] flex flex-col md:overflow-hidden">
+    <%# モバイル用 縦タイムライン %>
+    <div class="md:hidden p-4">
+      <div class="relative">
+        <%# 縦ライン %>
+        <div class="absolute left-[7px] top-3 bottom-3 w-0.5 bg-[#3713ec] opacity-30"></div>
+
+        <div class="flex flex-col gap-4">
+          <% @events.each do |event| %>
+            <div class="relative flex items-start gap-3">
+              <%# ドット %>
+              <div class="relative z-10 size-4 rounded-full bg-[#3713ec] border-[3px] border-white shadow-md mt-4 flex-shrink-0"></div>
+
+              <%# カード %>
+              <%= link_to event_path(event), class: "block flex-1 min-w-0" do %>
+                <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm p-4 flex flex-col hover:shadow-md transition-shadow">
+                  <div class="mb-2">
+                    <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-wider uppercase" style="<%= category_badge_style(event.category) %>">
+                      <%= event.category.name %>
+                    </span>
+                  </div>
+                  <h3 class="text-base font-medium text-[#111827] mb-1"><%= event.title %></h3>
+                  <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
+                  <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= markdown_to_plain(event.description) %></p>
+                  <% if event.characters.any? %>
+                    <p class="text-xs text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>
 
-    <%# タイムラインエリア %>
-    <div class="flex-1 relative overflow-x-auto" data-controller="timeline">
-      <%# 水平ライン %>
-      <div class="absolute left-0 right-0 top-1/2 h-0.5 bg-[#3713ec] opacity-30 -translate-y-1/2" style="min-width: <%= [@events.count * 352 + 400, 100].max %>px;"></div>
-
-      <%# タイムラインカード %>
-      <div class="flex items-center gap-16 px-12 absolute top-1/2 -translate-y-1/2" style="min-width: <%= [@events.count * 352 + 400, 100].max %>px;">
-        <% @events.each_with_index do |event, index| %>
-          <div class="flex flex-col items-center <%= index.even? ? 'pt-8' : 'pb-8' %>">
-            <% if index.even? %>
-              <%# カード上 + ドット下 %>
-              <%= link_to event_path(event), class: "block" do %>
-              <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm w-72 p-6 flex flex-col hover:shadow-md transition-shadow">
-                <div class="mb-2">
-                  <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-[0.25px] uppercase" style="<%= category_badge_style(event.category) %>">
-                    <%= event.category.name %>
-                  </span>
-                </div>
-                <h3 class="text-lg font-medium text-[#111827] mb-1"><%= event.title %></h3>
-                <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
-                <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= markdown_to_plain(event.description) %></p>
-                <% if event.characters.any? %>
-                  <p class="text-sm text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
-                <% end %>
-              </div>
-              <% end %>
-              <div class="flex flex-col items-center py-8 w-4">
-                <div class="size-4 rounded-full bg-[#3713ec] border-4 border-white shadow-md"></div>
-              </div>
-            <% else %>
-              <%# ドット上 + カード下 %>
-              <div class="flex flex-col items-center py-8 w-4">
-                <div class="size-4 rounded-full bg-[#3713ec] border-4 border-white shadow-md"></div>
-              </div>
-              <%= link_to event_path(event), class: "block" do %>
-              <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm w-72 p-6 flex flex-col hover:shadow-md transition-shadow">
-                <div class="mb-2">
-                  <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-[0.25px] uppercase" style="<%= category_badge_style(event.category) %>">
-                    <%= event.category.name %>
-                  </span>
-                </div>
-                <h3 class="text-lg font-medium text-[#111827] mb-1"><%= event.title %></h3>
-                <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
-                <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= markdown_to_plain(event.description) %></p>
-                <% if event.characters.any? %>
-                  <p class="text-sm text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
-                <% end %>
-              </div>
-              <% end %>
-            <% end %>
+    <%# デスクトップ用 横スクロールタイムライン %>
+    <div class="hidden md:flex md:flex-col md:flex-1 md:overflow-hidden">
+      <%# ヘッダー %>
+      <div class="backdrop-blur-sm bg-white/50 border-b border-[#e5e7eb] px-6 py-4 flex-shrink-0">
+        <div class="flex items-center justify-between">
+          <div>
+            <h1 class="text-xl font-medium text-black tracking-[3.2px]"><%= @study_unit.name %></h1>
           </div>
-        <% end %>
+        </div>
+      </div>
+
+      <%# タイムラインエリア %>
+      <div class="flex-1 relative overflow-x-auto" data-controller="timeline">
+        <%# 水平ライン %>
+        <div class="absolute left-0 right-0 top-1/2 h-0.5 bg-[#3713ec] opacity-30 -translate-y-1/2" style="min-width: <%= [@events.count * 352 + 400, 100].max %>px;"></div>
+
+        <%# タイムラインカード %>
+        <div class="flex items-center gap-16 px-12 absolute top-1/2 -translate-y-1/2" style="min-width: <%= [@events.count * 352 + 400, 100].max %>px;">
+          <% @events.each_with_index do |event, index| %>
+            <div class="flex flex-col items-center <%= index.even? ? 'pt-8' : 'pb-8' %>">
+              <% if index.even? %>
+                <%# カード上 + ドット下 %>
+                <%= link_to event_path(event), class: "block" do %>
+                <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm w-72 p-6 flex flex-col hover:shadow-md transition-shadow">
+                  <div class="mb-2">
+                    <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-[0.25px] uppercase" style="<%= category_badge_style(event.category) %>">
+                      <%= event.category.name %>
+                    </span>
+                  </div>
+                  <h3 class="text-lg font-medium text-[#111827] mb-1"><%= event.title %></h3>
+                  <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
+                  <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= markdown_to_plain(event.description) %></p>
+                  <% if event.characters.any? %>
+                    <p class="text-sm text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
+                  <% end %>
+                </div>
+                <% end %>
+                <div class="flex flex-col items-center py-8 w-4">
+                  <div class="size-4 rounded-full bg-[#3713ec] border-4 border-white shadow-md"></div>
+                </div>
+              <% else %>
+                <%# ドット上 + カード下 %>
+                <div class="flex flex-col items-center py-8 w-4">
+                  <div class="size-4 rounded-full bg-[#3713ec] border-4 border-white shadow-md"></div>
+                </div>
+                <%= link_to event_path(event), class: "block" do %>
+                <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm w-72 p-6 flex flex-col hover:shadow-md transition-shadow">
+                  <div class="mb-2">
+                    <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-[0.25px] uppercase" style="<%= category_badge_style(event.category) %>">
+                      <%= event.category.name %>
+                    </span>
+                  </div>
+                  <h3 class="text-lg font-medium text-[#111827] mb-1"><%= event.title %></h3>
+                  <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
+                  <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= markdown_to_plain(event.description) %></p>
+                  <% if event.characters.any? %>
+                    <p class="text-sm text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
+                  <% end %>
+                </div>
+                <% end %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -1,8 +1,26 @@
 <% provide(:title, @study_unit.name) %>
 
-<div class="flex h-[calc(100vh-64px)]">
-  <%# サイドバー %>
-  <aside class="w-64 border-r border-[#e5e7eb] bg-white flex flex-col justify-between px-6 py-6 flex-shrink-0">
+<div class="flex flex-col md:flex-row h-[calc(100vh-64px)] md:h-[calc(100vh-80px)]">
+  <%# モバイル用: 単元選択 + 凡例 %>
+  <div class="md:hidden bg-white border-b border-[#e5e7eb] px-4 py-3 flex-shrink-0 flex flex-col gap-3">
+    <%= form_tag "", method: :get, class: "flex gap-2 items-center" do %>
+      <label class="text-xs font-medium text-[#9ca3af] tracking-wider uppercase shrink-0">単元</label>
+      <%= select_tag :unit, options_for_select(@study_units.map { |u| [u.name, timeline_path(u)] }, timeline_path(@study_unit)),
+        class: "flex-1 border border-[#e2e8f0] rounded-lg px-3 py-2 text-sm",
+        data: { controller: "timeline-select", action: "change->timeline-select#navigate" } %>
+    <% end %>
+    <div class="flex flex-wrap gap-2">
+      <% @categories.each do |category| %>
+        <div class="flex items-center gap-1.5">
+          <div class="size-2.5 rounded-full border" style="<%= category_legend_style(category) %>"></div>
+          <span class="text-[11px] text-[#111827]"><%= category.name %></span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <%# デスクトップ用サイドバー %>
+  <aside class="hidden md:flex w-64 border-r border-[#e5e7eb] bg-white flex-col justify-between px-6 py-6 flex-shrink-0">
     <div>
       <p class="text-xs font-medium text-[#9ca3af] tracking-[1.2px] uppercase mb-6">学習単元を選択</p>
       <nav class="flex flex-col">
@@ -28,8 +46,8 @@
 
   <%# メインエリア %>
   <div class="flex-1 bg-[#fafafa] flex flex-col overflow-hidden">
-    <%# ヘッダー %>
-    <div class="backdrop-blur-sm bg-white/50 border-b border-[#e5e7eb] px-6 py-4 flex-shrink-0">
+    <%# ヘッダー (デスクトップのみ表示) %>
+    <div class="hidden md:block backdrop-blur-sm bg-white/50 border-b border-[#e5e7eb] px-6 py-4 flex-shrink-0">
       <div class="flex items-center justify-between">
         <div>
           <h1 class="text-xl font-medium text-black tracking-[3.2px]"><%= @study_unit.name %></h1>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -59,21 +59,7 @@
               <div class="relative z-10 size-4 rounded-full bg-[#3713ec] border-[3px] border-white shadow-md mt-4 flex-shrink-0"></div>
 
               <%# カード %>
-              <%= link_to event_path(event), class: "block flex-1 min-w-0" do %>
-                <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm p-4 flex flex-col hover:shadow-md transition-shadow">
-                  <div class="mb-2">
-                    <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-wider uppercase" style="<%= category_badge_style(event.category) %>">
-                      <%= event.category.name %>
-                    </span>
-                  </div>
-                  <h3 class="text-base font-medium text-[#111827] mb-1"><%= event.title %></h3>
-                  <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
-                  <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= markdown_to_plain(event.description) %></p>
-                  <% if event.characters.any? %>
-                    <p class="text-xs text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
-                  <% end %>
-                </div>
-              <% end %>
+              <%= render "shared/timeline_card", event: event, card_class: "flex-1 min-w-0" %>
             </div>
           <% end %>
         </div>
@@ -102,21 +88,7 @@
             <div class="flex flex-col items-center <%= index.even? ? 'pt-8' : 'pb-8' %>">
               <% if index.even? %>
                 <%# カード上 + ドット下 %>
-                <%= link_to event_path(event), class: "block" do %>
-                <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm w-72 p-6 flex flex-col hover:shadow-md transition-shadow">
-                  <div class="mb-2">
-                    <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-[0.25px] uppercase" style="<%= category_badge_style(event.category) %>">
-                      <%= event.category.name %>
-                    </span>
-                  </div>
-                  <h3 class="text-lg font-medium text-[#111827] mb-1"><%= event.title %></h3>
-                  <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
-                  <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= markdown_to_plain(event.description) %></p>
-                  <% if event.characters.any? %>
-                    <p class="text-sm text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
-                  <% end %>
-                </div>
-                <% end %>
+                <%= render "shared/timeline_card", event: event, card_class: "w-72" %>
                 <div class="flex flex-col items-center py-8 w-4">
                   <div class="size-4 rounded-full bg-[#3713ec] border-4 border-white shadow-md"></div>
                 </div>
@@ -125,21 +97,7 @@
                 <div class="flex flex-col items-center py-8 w-4">
                   <div class="size-4 rounded-full bg-[#3713ec] border-4 border-white shadow-md"></div>
                 </div>
-                <%= link_to event_path(event), class: "block" do %>
-                <div class="bg-white border border-[#e5e7eb] rounded-lg shadow-sm w-72 p-6 flex flex-col hover:shadow-md transition-shadow">
-                  <div class="mb-2">
-                    <span class="inline-block px-2 py-1 rounded text-[10px] font-medium tracking-[0.25px] uppercase" style="<%= category_badge_style(event.category) %>">
-                      <%= event.category.name %>
-                    </span>
-                  </div>
-                  <h3 class="text-lg font-medium text-[#111827] mb-1"><%= event.title %></h3>
-                  <p class="text-xs font-semibold text-[#3713ec] mb-2"><%= event.year %>年</p>
-                  <p class="text-sm text-[#4b5563] leading-relaxed line-clamp-3 mb-3"><%= markdown_to_plain(event.description) %></p>
-                  <% if event.characters.any? %>
-                    <p class="text-sm text-[#94a3b8]">代表人物：<%= event.characters.map(&:name).join("、") %></p>
-                  <% end %>
-                </div>
-                <% end %>
+                <%= render "shared/timeline_card", event: event, card_class: "w-72" %>
               <% end %>
             </div>
           <% end %>


### PR DESCRIPTION
## Summary
- 主要動線(TOP/記事一覧/出来事詳細/人物詳細/タイムライン/会員ページ群)をモバイルファースト設計で再構成
- 共通ヘッダーにハンバーガーメニューを実装
- viewport設定を明示化(`viewport-fit=cover`)、`<html lang=\"ja\">` 等もまとめて整える
- @tailwindcss/typography の prose クラス活用済の上にレスポンシブを重ねる
- ドロップダウンのstate管理を強化(resize時クローズ・aria-expanded同期)し、タイムラインカードのコード重複もpartial化で解消

## 対象ページ
**一般動線**
- TOP / 記事一覧 / 検索バー / フィルターサイドバー
- 出来事詳細 / 人物詳細 / タイムライン
- 共通ヘッダー(ハンバーガーメニュー)

**会員エリア**
- スケジュール(新規・編集・フォーム)
- プロフィール
- お気に入り
- アカウント設定

## 主な変更パターン
- 大きい固定値(`text-[72px]`, `px-20` 等)を `md:` `lg:` プレフィックスで段階化
- 多列グリッドを `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` で段階表示
- タイムラインはモバイルでは縦リスト、デスクトップでは横スクロール
- 曜日選択は `flex justify-between` で画面幅に収める
- ハンバーガー/フィルターアコーディオンを stimulus dropdown で実装

## 新規ファイル
- `app/javascript/controllers/timeline_select_controller.js` - select 変更で遷移
- `app/views/shared/_timeline_card.html.erb` - タイムラインカードpartial

## バグ温床への対処
- リサイズ時のメニュー開きっぱなしバグ対策(resize リスナー)
- aria-expanded を toggle/close/resize で自動更新
- タイムラインカードを1箇所に集約

## Test plan
- [ ] DevToolsスマホモード(iPhone等)で各ページが破綻なく表示される
- [ ] ハンバーガーメニューが開閉する/外クリック・リサイズで閉じる
- [ ] 記事一覧のフィルターをモバイルで開閉できる
- [ ] タイムラインがモバイルで縦に並ぶ、PCで横スクロールする
- [ ] スケジュールの曜日ボタンが7曜分画面幅に収まる
- [ ] プロフィールのスケジュール+最近チェック領域がスマホで縦並びになる
- [ ] viewportが正しく `width=device-width, initial-scale=1.0, viewport-fit=cover` に設定されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)