### PR TITLE
feat: Google Analytics(GA4)を導入

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ RESEND_API_KEY=your_resend_api_key_here
 CLOUDINARY_CLOUD_NAME=xxxxxxxx
 CLOUDINARY_API_KEY=xxxxxxxx
 CLOUDINARY_API_SECRET=xxxxxxxx
+# Google Analytics(GA4)の測定ID。本番(Render)の環境変数で設定する
+GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,25 @@
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+
+    <%# Google Analytics(GA4): 本番環境のみ計測。測定IDはRenderの環境変数で設定 %>
+    <% if Rails.env.production? && ENV["GA_MEASUREMENT_ID"].present? %>
+      <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV["GA_MEASUREMENT_ID"] %>"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        <%# 自動page_viewはオフにし、Turboのページ遷移ごとに手動送信する %>
+        gtag('config', '<%= ENV["GA_MEASUREMENT_ID"] %>', { send_page_view: false });
+        document.addEventListener('turbo:load', function() {
+          gtag('event', 'page_view', {
+            page_location: window.location.href,
+            page_title: document.title
+          });
+        });
+      </script>
+    <% end %>
     <%# Turboのリンク先読み(prefetch)を無効化: article_viewsの記録が実クリックと一致しないため %>
     <meta name="turbo-prefetch" content="false">
 


### PR DESCRIPTION
## 概要
アクセス解析のため Google Analytics 4 (GA4) を導入します。

## 変更内容
- `app/views/layouts/application.html.erb` の `<head>` にGA4タグ(gtag.js)を追加
  - **本番環境のみ計測**: `Rails.env.production?` かつ測定IDが設定されている時だけタグを出力（開発・テスト中のアクセスを混入させない）
  - **Turbo対応**: 自動page_viewはオフ(`send_page_view: false`)にし、`turbo:load` のたびに `page_view` を手動送信。Turbo Driveによるページ遷移も漏れなく計測する
- `.env.example` に `GA_MEASUREMENT_ID` を追記

## マージ後にやること
1. Renderダッシュボードで環境変数 `GA_MEASUREMENT_ID` を設定（値: `G-XXXXXXXXXX`）
2. 再デプロイ後、GA4のリアルタイムレポートで計測を確認

## テスト
- `spec/requests/static_pages_spec.rb` がグリーン（レイアウト描画に影響なし、テスト環境ではタグ非出力を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)