### PR TITLE
fix: 記事・人物カードから固定表示の国名を削除

### DIFF
--- a/app/views/articles/_card.html.erb
+++ b/app/views/articles/_card.html.erb
@@ -16,16 +16,7 @@
 
       <%# コンテンツ %>
       <div class="p-5 flex flex-col gap-2">
-        <div class="flex items-center justify-between">
-          <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider"><%= article.year %>年</span>
-          <div class="flex items-center gap-1">
-            <svg class="size-3 text-[#94a3b8]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-            </svg>
-            <span class="text-xs text-[#94a3b8]">ヨーロッパ</span>
-          </div>
-        </div>
+        <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider"><%= article.year %>年</span>
         <h2 class="text-lg font-medium text-[#0f172a]"><%= article.title %></h2>
         <p class="text-sm text-[#475569] line-clamp-2"><%= markdown_to_plain(article.description) %></p>
       </div>
@@ -49,16 +40,7 @@
 
       <%# コンテンツ %>
       <div class="p-5 flex flex-col gap-2">
-        <div class="flex items-center justify-between">
-          <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider"><%= article.year %>年</span>
-          <div class="flex items-center gap-1">
-            <svg class="size-3 text-[#94a3b8]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-            </svg>
-            <span class="text-xs text-[#94a3b8]">イタリア</span>
-          </div>
-        </div>
+        <span class="text-xs font-bold text-[#3713ec] uppercase tracking-wider"><%= article.year %>年</span>
         <h2 class="text-lg font-medium text-[#0f172a]"><%= article.name %></h2>
         <p class="text-sm text-[#475569] line-clamp-2"><%= markdown_to_plain(article.description) %></p>
       </div>


### PR DESCRIPTION
## 概要
記事一覧のカードに表示されていた国名（地域名）を削除します。

## 背景
カード右側に表示されていた地域名は、デザインのモックアップ時の仮テキストがそのまま残っていたもので、以下の問題がありました：
- `region` データと一切紐づいておらず、**全カードに同一の固定文字列**が表示されていた
  - 記事(Event)カード: 必ず「ヨーロッパ」
  - 人物(Character)カード: 必ず「イタリア」
- 実際の記事の国・地域とは無関係で、誤情報になっていた

## 変更内容
- `app/views/articles/_card.html.erb` から、両カードの地図ピンアイコン＋地域名テキストを削除
- 年代（`◯◯年`）表示はそのまま残す

## テスト
- `spec/requests/articles_spec.rb` 20件グリーン（描画への影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)