### PR TITLE
fix: brakemanを8.0.5に更新しCIのscan_ruby失敗を解消

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -567,7 +567,7 @@ CHECKSUMS
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,24 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.3 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 673,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Rails本体のEOLはRailsアップグレードで別途対応する。CIをブロックしないよう一時的に無視"
+    }
+  ],
+  "brakeman_version": "8.0.5"
+}


### PR DESCRIPTION
## 概要

CIの `scan_ruby` ジョブが exit 5 で失敗していた問題を修正します。

## 原因

`bin/brakeman` は `--ensure-latest` フラグ付きで実行されるため、インストール済みのbrakemanが最新版でないと exit 5 で失敗します。brakeman 8.0.5 がリリースされ、ロックされていた 8.0.4 が「最新ではない」と判定されて全PR・mainのCIが落ちる状態でした。

> Brakeman 8.0.4 is not the latest version 8.0.5

## 対応

- `brakeman` を 8.0.4 → 8.0.5 に更新
- 8.0.5で追加された `EOLRails` チェック（Rails 7.2.3 のサポート終了 2026-08-09 を知らせる警告）は情報提供的な内容のため、`config/brakeman.ignore` に登録して一時的に無視
  - Rails本体のEOL対応は別途アップグレードで実施予定

## 確認

- `bin/brakeman --no-pager` → exit 0 / Security Warnings: 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)